### PR TITLE
Select container rendering and format updates

### DIFF
--- a/src/color-field/ColorField.stories.ts
+++ b/src/color-field/ColorField.stories.ts
@@ -4,15 +4,7 @@ import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { OmniFormElement } from '../core/OmniFormElement.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -22,7 +14,7 @@ import './ColorField.js';
 
 export default {
     title: 'UI Components/Color Field',
-    component: 'omni-color-field',
+    component: 'omni-color-field'
 } as CSFIdentifier;
 
 export const Interactive: ComponentStoryFormat<BaseArgs> = {

--- a/src/currency-field/CurrencyField.stories.ts
+++ b/src/currency-field/CurrencyField.stories.ts
@@ -4,16 +4,7 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    DisabledStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -23,7 +14,7 @@ import './CurrencyField.js';
 
 export default {
     title: 'UI Components/Currency Field',
-    component: 'omni-currency-field',
+    component: 'omni-currency-field'
 } as CSFIdentifier;
 
 interface Args extends BaseArgs {

--- a/src/number-field/NumberField.stories.ts
+++ b/src/number-field/NumberField.stories.ts
@@ -4,16 +4,7 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    DisabledStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -23,7 +14,7 @@ import './NumberField.js';
 
 export default {
     title: 'UI Components/Number Field',
-    component: 'omni-number-field',
+    component: 'omni-number-field'
 } as CSFIdentifier;
 
 export const Interactive: ComponentStoryFormat<BaseArgs> = {

--- a/src/numeric-field/NumericField.stories.ts
+++ b/src/numeric-field/NumericField.stories.ts
@@ -3,16 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    DisabledStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -25,7 +16,7 @@ import './NumericField.js';
 
 export default {
     title: 'UI Components/Numeric Field',
-    component: 'omni-numeric-field',
+    component: 'omni-numeric-field'
 } as CSFIdentifier;
 
 interface Args extends BaseArgs {

--- a/src/password-field/PasswordField.stories.ts
+++ b/src/password-field/PasswordField.stories.ts
@@ -3,16 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    DisabledStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';

--- a/src/search-field/SearchField.ts
+++ b/src/search-field/SearchField.ts
@@ -76,10 +76,12 @@ export class SearchField extends OmniFormElement {
         super._focusLost();
 
         // Dispatch standard DOM event to cater for single clear.
-        this.dispatchEvent(new Event('change', {
-            bubbles: true,
-            composed: true
-        }));
+        this.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: true
+            })
+        );
     }
 
     static override get styles() {

--- a/src/select/Select.stories.ts
+++ b/src/select/Select.stories.ts
@@ -42,7 +42,7 @@ const displayItems = [
 
 const stringItems = ['Bruce Wayne', 'Clark Kent', 'Barry Allen', 'Arthur Curry', 'Hal Jordan'];
 
-async function promiseDisplayItems(data: Record<string,unknown>[]) {
+async function promiseDisplayItems(data: Record<string, unknown>[]) {
     await new Promise<void>((r) => setTimeout(() => r(), 2000));
     return data as SelectTypes;
 }
@@ -79,7 +79,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         disabled: false,
         prefix: '',
         suffix: '',
-        items: displayItems as Record<string,unknown>[],
+        items: displayItems as Record<string, unknown>[],
         displayField: 'label',
         idField: 'id',
         loading_indicator: ''
@@ -310,7 +310,7 @@ export const Disabled: ComponentStoryFormat<Args> = {
     args: {
         label: 'Disabled',
         disabled: true,
-        items: displayItems as Record<string,unknown>[]
+        items: displayItems as Record<string, unknown>[]
     } as Args,
     play: async (context) => {
         const select = within(context.canvasElement).getByTestId<Select>('test-select');

--- a/src/text-field/TextField.stories.ts
+++ b/src/text-field/TextField.stories.ts
@@ -3,16 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import {
-    LabelStory,
-    BaseArgs,
-    HintStory,
-    ErrorStory,
-    DisabledStory,
-    ValueStory,
-    PrefixStory,
-    SuffixStory
-} from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -22,7 +13,7 @@ import './TextField.js';
 
 export default {
     title: 'UI Components/Text Field',
-    component: 'omni-text-field',
+    component: 'omni-text-field'
 } as CSFIdentifier;
 
 export const Interactive: ComponentStoryFormat<BaseArgs> = {

--- a/src/utils/StoryUtils.ts
+++ b/src/utils/StoryUtils.ts
@@ -644,7 +644,8 @@ async function setupThemes() {
                                     <div class="code-modal">
                                         <span class="flex-row">
                                             <h3 id="custom-theme" style="margin-left: 0px;">Custom Theme</h3>
-                                            <input class="hidden" id="cssValue" type="file" accept=".css" @input="${(e2: Event) => uploadTheme(e2)}" />
+                                            <input class="hidden" id="cssValue" type="file" accept=".css" @input="${(e2: Event) =>
+                                                uploadTheme(e2)}" />
                                             <omni-button class="docs-omni-component" label="Upload" type="secondary" @click="${(e3: Event) =>
                                                 uploadThemeClick(e3)}" ></omni-button>
                                         </span>


### PR DESCRIPTION
### Description:

Select component updates

- Introduce emptyMessage property to allow the user to set the message displayed when the select component has no items to render.
- Introduce functionality to make the items container max-height adjust in size.
- Updates to function and variable names.
- Updates to default css variable values.
- Format updates.

Test results 

![image](https://user-images.githubusercontent.com/22874454/206429907-edf70029-9247-448a-be6d-812eece9e0f2.png)

Manual Pull request action run

https://github.com/capitec/omni-components/actions/runs/3647830799

Default render

![default render](https://user-images.githubusercontent.com/22874454/206433069-e4262a68-deea-4612-920c-2d9f33d454e6.gif)

Shrink item container to fit when rendering below the input

![shrink item container to fit viewport](https://user-images.githubusercontent.com/22874454/206433300-5ac8a587-8e55-4338-a42c-9e580df56c95.gif)

Shrink item container to fit when rendering above the input

![shrink item container to fit viewport top render](https://user-images.githubusercontent.com/22874454/206434371-273783d6-9fe3-4058-a5b0-d7a5b9faf812.gif)

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
