### PR TITLE
Play function fixes

### DIFF
--- a/src/currency-field/CurrencyField.stories.ts
+++ b/src/currency-field/CurrencyField.stories.ts
@@ -86,15 +86,17 @@ export const Interactive: ComponentStoryFormat<Args> = {
         }
 
         // Backspacing to cover the removal of cents and cents separator
-        const backspace = '{Backspace}';
+        const backspace = '{Backspace>2/}';
         // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
         setUIValueClean(inputField);
         await userEvent.type(inputField, backspace, {
-            initialSelectionStart: 10,
-            initialSelectionEnd: 10
+            initialSelectionStart: 12,
+            initialSelectionEnd: 12
         });
 
         await currencyField.updateComplete;
+
+        console.log('After backspacing', inputField.value);
 
         // TODO: Fix race conditions in tests
         if (navigator.userAgent === 'Test Runner') {

--- a/src/email-field/EmailField.stories.ts
+++ b/src/email-field/EmailField.stories.ts
@@ -1,5 +1,6 @@
 import { waitFor, within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/UI.js';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -41,10 +42,14 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
     },
     play: async (context) => {
         const emailField = within(context.canvasElement).getByTestId<EmailField>('test-email-field');
+        emailField.value = '';
+        
         const input = jest.fn();
         emailField.addEventListener('input', input);
 
-        const inputField = emailField.shadowRoot?.getElementById('inputField');
+        const inputField = emailField.shadowRoot?.getElementById('inputField') as HTMLInputElement;
+        // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
+        setUIValueClean(inputField);
 
         await userEvent.type(inputField as Element, 'johndoe@gmail.com', {
             pointerEventsCheck: 0

--- a/src/email-field/EmailField.stories.ts
+++ b/src/email-field/EmailField.stories.ts
@@ -43,7 +43,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
     play: async (context) => {
         const emailField = within(context.canvasElement).getByTestId<EmailField>('test-email-field');
         emailField.value = '';
-        
+
         const input = jest.fn();
         emailField.addEventListener('input', input);
 

--- a/src/password-field/PasswordField.stories.ts
+++ b/src/password-field/PasswordField.stories.ts
@@ -1,5 +1,6 @@
 import { waitFor, within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/UI.js';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -52,12 +53,16 @@ export const Interactive: ComponentStoryFormat<Args> = {
     },
     play: async (context) => {
         const passwordField = within(context.canvasElement).getByTestId<PasswordField>('test-password-field');
+        passwordField.value = '';
+
         const interactions = jest.fn();
         passwordField.addEventListener('input', interactions);
         passwordField.addEventListener('click', interactions);
 
         const inputField = passwordField.shadowRoot?.getElementById('inputField') as HTMLInputElement;
-
+        // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
+        setUIValueClean(inputField);
+        
         const showSlotElement = passwordField.shadowRoot?.querySelector<HTMLSlotElement>('slot[name=show]');
         await expect(showSlotElement).toBeTruthy();
         await userEvent.click(showSlotElement as HTMLSlotElement, {

--- a/src/password-field/PasswordField.stories.ts
+++ b/src/password-field/PasswordField.stories.ts
@@ -62,7 +62,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         const inputField = passwordField.shadowRoot?.getElementById('inputField') as HTMLInputElement;
         // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
         setUIValueClean(inputField);
-        
+
         const showSlotElement = passwordField.shadowRoot?.querySelector<HTMLSlotElement>('slot[name=show]');
         await expect(showSlotElement).toBeTruthy();
         await userEvent.click(showSlotElement as HTMLSlotElement, {

--- a/src/pin-field/PinField.stories.ts
+++ b/src/pin-field/PinField.stories.ts
@@ -53,13 +53,14 @@ export const Interactive: ComponentStoryFormat<Args> = {
     },
     play: async (context) => {
         const pinField = within(context.canvasElement).getByTestId<PinField>('test-pin-field');
-        // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
+        pinField.value = '';
 
         const interactions = jest.fn();
         pinField.addEventListener('input', interactions);
         pinField.addEventListener('click', interactions);
 
         const inputField = pinField.shadowRoot?.getElementById('inputField') as HTMLInputElement;
+        // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
         setUIValueClean(inputField);
 
         const showSlotElement = pinField.shadowRoot?.querySelector<HTMLSlotElement>('slot[name=show]');

--- a/src/text-field/TextField.stories.ts
+++ b/src/text-field/TextField.stories.ts
@@ -1,5 +1,6 @@
 import { within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/UI.js';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -41,10 +42,14 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
     },
     play: async (context) => {
         const textField = within(context.canvasElement).getByTestId<TextField>('test-text-field');
+        textField.value = '';
+
         const input = jest.fn();
         textField.addEventListener('input', input);
 
-        const inputField = textField.shadowRoot?.getElementById('inputField') as HTMLElement;
+        const inputField = textField.shadowRoot?.getElementById('inputField') as HTMLInputElement;
+        // Required to clear userEvent Symbol that keeps hidden state of previously typed values via userEvent. If not cleared this cannot be run multiple times with the same results
+        setUIValueClean(inputField);
 
         await userEvent.type(inputField, 'Value Update', {
             pointerEventsCheck: 0


### PR DESCRIPTION
### Description:

**On the Omni docs site some components play functions were failing**

**Currency Field** - Interactive.
**Email Field** - Interactive on multi runs.
**Password Field** - Interactive on multi runs.
**Pin Field** - Interactive on multi runs.
**Text Field** - Interactive on multi runs.

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/22874454/223375916-63f4ad84-42fb-49ea-98f2-37b90283aef8.png)

### All Submissions:

* [x] I have followed the guidelines in the Contributing document.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
