### PR TITLE
111-change-request-icon-component-symmetrical-attribute

### DIFF
--- a/src/icon/Icon.stories.ts
+++ b/src/icon/Icon.stories.ts
@@ -17,17 +17,21 @@ export default {
 interface Args {
     size: (typeof sizeOptions)[number];
     icon: string;
+    symmetrical: boolean;
     '[Default Slot]': string;
 }
 
 export const Interactive: ComponentStoryFormat<Args> = {
     render: (args: Args) => html`
-    <!-- Icons loaded by content path instead of font-based or slotted content will not be able to be styled directly -->
-
-    <omni-icon data-testid="test-icon" size="${ifNotEmpty(args.size)}" icon="${ifNotEmpty(args.icon)}">
-      ${unsafeHTML(args['[Default Slot]'])}
-    </omni-icon>
-  `,
+        <!-- Icons loaded by content path instead of font-based or slotted content will not be able to be styled directly -->
+        <omni-icon 
+            data-testid="test-icon" 
+            size="${ifNotEmpty(args.size)}" 
+            icon="${ifNotEmpty(args.icon)}"
+            ?symmetrical=${args.symmetrical}>
+            ${unsafeHTML(args['[Default Slot]'])}
+        </omni-icon>
+    `,
     name: 'Interactive',
     args: {
         size: 'default',
@@ -36,12 +40,11 @@ export const Interactive: ComponentStoryFormat<Args> = {
     viewBox="0 0 16 16"
     xmlns="http://www.w3.org/2000/svg"
     width="100%"
-    height="100%"
-  >
+    height="100%">
     <g transform="translate(-2,-2)">
-      <path d="m8.229 14.062-3.521-3.541L5.75 9.479l2.479 2.459 6.021-6L15.292 7Z" />
+        <path d="m8.229 14.062-3.521-3.541L5.75 9.479l2.479 2.459 6.021-6L15.292 7Z" />
     </g>
-  </svg>`,
+</svg>`,
         icon: undefined as unknown as string
     },
     play: async (context) => {
@@ -53,7 +56,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
 };
 
 export const SVG: ComponentStoryFormat<Args> = {
-    render: (args: Args) => html` <omni-icon data-testid="test-icon" size="${args.size}"> ${unsafeHTML(args['[Default Slot]'])} </omni-icon> `,
+    render: (args: Args) => html`<omni-icon data-testid="test-icon" size="${args.size}">${unsafeHTML(args['[Default Slot]'])}</omni-icon>`,
     name: 'SVG',
     description: 'Set html/svg content to display as an icon.',
     args: {
@@ -64,8 +67,7 @@ export const SVG: ComponentStoryFormat<Args> = {
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
                 width="100%"
-                height="100%"
-              >
+                height="100%">
                 <g transform="translate(-2,-2)">
                   <path d="m8.229 14.062-3.521-3.541L5.75 9.479l2.479 2.459 6.021-6L15.292 7Z" />
                 </g>
@@ -85,7 +87,7 @@ export const Local_Source: ComponentStoryFormat<Args> = {
     <!-- Icons loaded by content path instead of font-based or slotted content will not be able to be styled directly -->
 
     <omni-icon data-testid="test-icon" size="${args.size}" icon="${args.icon}"></omni-icon>
-  `,
+    `,
     name: 'Local Source',
     description: 'Set the icon to display as a local source file.',
     args: {
@@ -105,7 +107,7 @@ export const Remote_Source: ComponentStoryFormat<Args> = {
     <!-- Icons loaded by content path instead of font-based or slotted content will not be able to be styled directly -->
 
     <omni-icon data-testid="test-icon" size="${args.size}" icon="${args.icon}"></omni-icon>
-  `,
+    `,
     name: 'Remote Source',
     description: 'Set the icon to display as a remote file.',
     args: {
@@ -126,8 +128,8 @@ export const Material: ComponentStoryFormat<Args> = {
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <!-- ------------------------------------------------------------- -->
 
-    <omni-icon data-testid="test-icon" size="${args.size}" icon="${args.icon}"> </omni-icon>
-  `,
+    <omni-icon data-testid="test-icon" size="${args.size}" icon="${args.icon}"></omni-icon>
+    `,
     description: 'Set the icon to display as a font icon from the Material Icons library.',
     args: {
         size: 'default',
@@ -138,5 +140,68 @@ export const Material: ComponentStoryFormat<Args> = {
         const materialElement = icon.shadowRoot?.querySelector<HTMLElement>('.material-icon');
         await expect(materialElement).toBeTruthy();
         await expect(materialElement?.innerText).toEqual(Material.args?.icon?.replace('@material/', ''));
+    }
+};
+
+export const Asymmetrical: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+        <omni-icon 
+            data-testid="test-icon" 
+            size="${args.size}" 
+            ?symmetrical=${args.symmetrical}>
+            <svg 
+                viewBox="0 0 138 26" 
+                fill="none" 
+                stroke-width="2.3" 
+                stroke-linecap="round" 
+                stroke-linejoin="round"
+                width="100%"
+                height="100%"
+                title="CodePen">
+                    <path d="M15 8a7 7 0 1 0 0 10m7-8.7L33 2l11 7.3v7.4L33 24l-11-7.3zm0 0 11 7.4 11-7.4m0 7.4L33 9.3l-11 7.4M33 2v7.3m0 7.4V24M52 6h5a7 7 0 0 1 0 14h-5zm28 0h-9v14h9m-9-7h6m11 1h6a4 4 0 0 0 0-8h-6v14m26-14h-9v14h9m-9-7h6m11 7V6l11 14V6"></path>
+                </svg>
+        </omni-icon>
+    `,
+    description: () => html`Renders the icon by aligning only the inner height to the <strong>size</strong> attribute, this is the default behavior.`,
+    args: {
+        size: 'large',
+        symmetrical: false
+    },
+    play: async (context) => {
+        const icon = within(context.canvasElement).getByTestId<Icon>('test-icon');
+        const svg = icon.querySelector('svg') as SVGElement;
+        await expect(svg.clientWidth).not.toEqual(svg.clientHeight);
+    }
+};
+
+export const Symmetrical: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+        <omni-icon 
+            data-testid="test-icon" 
+            size="${args.size}" 
+            ?symmetrical=${args.symmetrical}>
+            <svg 
+                viewBox="0 0 138 26" 
+                fill="none" 
+                stroke-width="2.3" 
+                stroke-linecap="round" 
+                stroke-linejoin="round"
+                width="100%"
+                height="100%"
+                title="CodePen">
+                    <path d="M15 8a7 7 0 1 0 0 10m7-8.7L33 2l11 7.3v7.4L33 24l-11-7.3zm0 0 11 7.4 11-7.4m0 7.4L33 9.3l-11 7.4M33 2v7.3m0 7.4V24M52 6h5a7 7 0 0 1 0 14h-5zm28 0h-9v14h9m-9-7h6m11 1h6a4 4 0 0 0 0-8h-6v14m26-14h-9v14h9m-9-7h6m11 7V6l11 14V6"></path>
+                </svg>
+        </omni-icon>
+    `,
+    description: () =>
+        html`Renders the icon by aligning both the inner height and width to the <strong>size</strong> attribute, creating a 1:1 aspect ratio.`,
+    args: {
+        size: 'large',
+        symmetrical: true
+    },
+    play: async (context) => {
+        const icon = within(context.canvasElement).getByTestId<Icon>('test-icon');
+        const svg = icon.querySelector('svg') as SVGElement;
+        await expect(svg.clientWidth).toEqual(svg.clientHeight);
     }
 };

--- a/src/icon/Icon.stories.ts
+++ b/src/icon/Icon.stories.ts
@@ -72,7 +72,7 @@ export const SVG: ComponentStoryFormat<Args> = {
                   <path d="m8.229 14.062-3.521-3.541L5.75 9.479l2.479 2.459 6.021-6L15.292 7Z" />
                 </g>
               </svg>
-              `
+        `
     },
     play: async (context) => {
         const icon = within(context.canvasElement).getByTestId<Icon>('test-icon');

--- a/src/icon/Icon.ts
+++ b/src/icon/Icon.ts
@@ -1,5 +1,6 @@
 import { html, css, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { OmniElement } from '../core/OmniElement.js';
 
 /**
@@ -55,113 +56,147 @@ export class Icon extends OmniElement {
      */
     @property({ type: String, reflect: true }) icon?: string;
 
+    /**
+     * When true, enforces 1:1 width and height of the icon.
+     * @attr
+     */
+    @property({ type: Boolean, reflect: true }) symmetrical?: boolean;
+
     static override get styles() {
         return [
             super.styles,
             css`
-        :host {
-          width: fit-content;
-          justify-content: center;
-          color: var(--omni-icon-fill, currentColor);
-          fill: var(--omni-icon-fill, currentColor);
-          background-color: var(--omni-icon-background-color);
-        }
+                :host {
+                    width: fit-content;
+                    justify-content: center;
+                    color: var(--omni-icon-fill, currentColor);
+                    fill: var(--omni-icon-fill, currentColor);
+                    stroke: var(--omni-icon-fill, currentColor);
+                    background-color: var(--omni-icon-background-color);
+                }
 
-        /* MATERIAL ICON STYLES */
+                /* MATERIAL ICON STYLES */
 
-        .material-icon {
-          font-family: 'Material Icons';
-          font-weight: normal;
-          font-style: normal;
-          display: inline-block;
-          line-height: 1;
-          text-transform: none;
-          letter-spacing: normal;
-          word-wrap: normal;
-          white-space: nowrap;
-          direction: ltr;
-          padding: 0px;
-          margin: 0px;
+                .material-icon {
+                    font-family: 'Material Icons';
+                    font-weight: normal;
+                    font-style: normal;
+                    display: inline-block;
+                    line-height: 1;
+                    text-transform: none;
+                    letter-spacing: normal;
+                    word-wrap: normal;
+                    white-space: nowrap;
+                    direction: ltr;
+                    padding: 0px;
+                    margin: 0px;
 
-          align-self: center;
-          justify-self: center;
+                    align-self: center;
+                    justify-self: center;
 
-          /* Support for all WebKit browsers. */
-          -webkit-font-smoothing: antialiased;
+                    /* Support for all WebKit browsers. */
+                    -webkit-font-smoothing: antialiased;
 
-          /* Support for Safari and Chrome. */
-          text-rendering: optimizeLegibility;
+                    /* Support for Safari and Chrome. */
+                    text-rendering: optimizeLegibility;
 
-          /* Support for Firefox. */
-          -moz-osx-font-smoothing: grayscale;
+                    /* Support for Firefox. */
+                    -moz-osx-font-smoothing: grayscale;
 
-          /* Support for IE. */
-          font-feature-settings: 'liga';
-        }
+                    /* Support for IE. */
+                    font-feature-settings: 'liga';
+                }
 
-        .material-icon.large {
-          font-size: var(--omni-icon-size-large, 48px);
-        }
+                .material-icon.large {
+                    font-size: var(--omni-icon-size-large, 48px);
+                }
 
-        .material-icon.medium {
-          font-size: var(--omni-icon-size-medium, 32px);
-        }
+                .material-icon.medium {
+                    font-size: var(--omni-icon-size-medium, 32px);
+                }
 
-        .material-icon.small {
-          font-size: var(--omni-icon-size-small, 16px);
-        }
+                .material-icon.small {
+                    font-size: var(--omni-icon-size-small, 16px);
+                }
 
-        .material-icon.extra-small {
-          font-size: var(--omni-icon-size-extra-small, 8.25px);
-        }
+                .material-icon.extra-small {
+                    font-size: var(--omni-icon-size-extra-small, 8.25px);
+                }
 
-        .material-icon.default {
-          font-size: var(--omni-icon-size-default, 24px);
-        }
+                .material-icon.default {
+                    font-size: var(--omni-icon-size-default, 24px);
+                }
 
-        /* SVG ICON STYLES */
+                /* SVG ICON STYLES */
 
-        .svg-icon.large {
-          height: var(--omni-icon-size-large, 48px);
-          /*width: 48px;*/
-        }
+                .svg-icon.large {
+                    height: var(--omni-icon-size-large, 48px);
+                }
 
-        .svg-icon.medium {
-          height: var(--omni-icon-size-medium, 32px);
-          /*width: 32px;*/
-        }
+                .svg-icon.large.symmetrical {
+                    width: var(--omni-icon-size-large, 48px);
+                }
 
-        .svg-icon.small {
-          height: var(--omni-icon-size-small, 16px);
-          /*width: 16px;*/
-        }
+                .svg-icon.medium {
+                    height: var(--omni-icon-size-medium, 32px);
+                }
 
-        .svg-icon.extra-small {
-          height: var(--omni-icon-size-extra-small, 8.25px);
-          /*width: 16px;*/
-        }
+                .svg-icon.medium.symmetrical {
+                    width: var(--omni-icon-size-medium, 32px);
+                }
 
-        .svg-icon.default {
-          height: var(--omni-icon-size-default, 24px);
-          /*width: 24px;*/
-        }
-      `
+                .svg-icon.small {
+                    height: var(--omni-icon-size-small, 16px);
+                }
+
+                .svg-icon.small.symmetrical {
+                    width: var(--omni-icon-size-small, 16px);
+                }
+
+                .svg-icon.extra-small {
+                    height: var(--omni-icon-size-extra-small, 8.25px);
+                }
+
+                .svg-icon.extra-small.symmetrical {
+                    width: var(--omni-icon-size-extra-small, 8.25px);
+                }
+
+                .svg-icon.default {
+                    height: var(--omni-icon-size-default, 24px);
+                }
+
+                .svg-icon.default.symmetrical {
+                    width: var(--omni-icon-size-default, 24px);
+                }
+            `
         ];
     }
 
     override render(): TemplateResult {
+        const iconClassMap = classMap({
+            ['svg-icon']: true,
+            [`${this.size}`]: this.size,
+            [`symmetrical`]: this.symmetrical ?? false
+        });
+
         if (this.icon) {
             if (this.icon.startsWith('@material/')) {
                 return html`<div class="material-icon ${this.size}">${this.icon.replace('@material/', '')}</div>`;
             }
-            return html`<img class="svg-icon ${this.size}" src="${this.icon}" alt="${this.icon}" />`;
+
+            return html`
+                <img 
+                    class=${iconClassMap}
+                    src="${this.icon}" 
+                    alt="${this.icon}" />
+            `;
         }
 
         return html`
-      <div class="svg-icon ${this.size}">
-        <slot></slot>
-      </div>
-    `;
+            <div class=${iconClassMap}>
+                <slot></slot>
+            </div>
+        `;
     }
 }
 


### PR DESCRIPTION
### Description:

Closes #111 .

Added two stories to reflect addition of `symmetrical` attribute:

1. Asymmetrical - Shows how a rectangular icon retains its original aspect ratio, constrained to the inner height _only_.
2. Symmetrical - Shows how a rectangular icon retains its original aspect ratio, constrained to _both_ the inner width and height.

### Screenshots (if appropriate):

<img width="1345" alt="Screenshot 2023-04-25 at 14 49 04" src="https://user-images.githubusercontent.com/10812446/234281352-c4306a60-f320-4104-9eb5-eed7acee8f7f.png">


### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
