### PR TITLE
Component updates: Based on feedback from use cases

### DIFF
--- a/src/color-field/ColorField.stories.ts
+++ b/src/color-field/ColorField.stories.ts
@@ -4,7 +4,7 @@ import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { OmniFormElement } from '../core/OmniFormElement.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, ClearableStory, HintStory, ErrorStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -58,6 +58,8 @@ export const Hint = HintStory<ColorField, BaseArgs>('omni-color-field');
 export const Error_Label = ErrorStory<ColorField, BaseArgs>('omni-color-field');
 
 export const Value = ValueStory<ColorField, BaseArgs>('omni-color-field', '#f6b73c');
+
+export const Clear = ClearableStory<ColorField, BaseArgs>('omni-color-field', '#f6b73c');
 
 export const Prefix = PrefixStory<ColorField, BaseArgs>('omni-color-field');
 

--- a/src/color-field/ColorField.ts
+++ b/src/color-field/ColorField.ts
@@ -84,7 +84,6 @@ export class ColorField extends OmniFormElement {
           font-family: var(--omni-color-field-font-family, var(--omni-font-family));
           font-size: var(--omni-color-field-font-size, var(--omni-font-size));
           font-weight: var(--omni-color-field-font-weight, var(--omni-font-weight));
-          height: var(--omni-color-field-height, 100%);
           min-height: var(--omni-color-field-min-height, 20px);
           min-width: var(--omni-color-field-min-width, 100px);
           padding: var(--omni-color-field-padding, 10px);

--- a/src/core/OmniFormElement.ts
+++ b/src/core/OmniFormElement.ts
@@ -3,10 +3,12 @@ export { ifDefined } from 'lit/directives/if-defined.js';
 import { property } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 import OmniElement from './OmniElement.js';
+import '../icons/Clear.icon.js';
 
 /**
  * Base class used by form components to share common properties, styles and functionality.
  *
+ * @slot clear - Replaces the icon for the clear slot.
  * @slot prefix - Replaces the icon for the prefix slot.
  * @slot suffix - Replaces the icon for the suffix slot.
  *
@@ -77,6 +79,11 @@ import OmniElement from './OmniElement.js';
  * @cssprop --omni-form-disabled-hover-color - Form disabled hover color.
  * @cssprop --omni-form-error-hover-color - Form error hover color.
  *
+ * @cssprop --omni-form-clear-control-margin-right - Form clear control right margin.
+ * @cssprop --omni-form-clear-control-margin-left -  Form clear control left margin.
+ * @cssprop --omni-form-clear-control-width - Form clear control width.
+ * @cssprop --omni-form-clear-icon-color - Form clear icon color.
+ *
  */
 export class OmniFormElement extends OmniElement {
     /**
@@ -114,6 +121,30 @@ export class OmniFormElement extends OmniElement {
      * @attr
      */
     @property({ type: Boolean, reflect: true }) disabled = false;
+
+    /**
+     * Toggles the ability to clear the value of the component.
+     * @attr
+     */
+    @property({ type: Boolean, reflect: true }) clearable = false;
+
+    protected _onClearClick(e: MouseEvent) {
+        if (this.disabled) {
+            return e.stopImmediatePropagation();
+        }
+
+        //this.value = '';
+
+        this.value = null as unknown as string;
+
+        // Dispatch standard DOM event to cater for single clear.
+        this.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: true
+            })
+        );
+    }
 
     static override get styles(): CSSResultGroup {
         return [
@@ -328,7 +359,27 @@ export class OmniFormElement extends OmniElement {
                     }
                 }
 
-                
+                .clear-control {
+                    display: flex;
+                  
+                    margin-right: var(--omni-form-clear-control-margin-right, 10px);
+                    margin-left: var(--omni-form-clear-control-margin-left, 10px);
+                    width: var(--omni-form-clear-control-width, 20px);
+                }
+
+                .clear-click {
+                    display: flex;
+                }
+
+                .clear-icon {
+                    fill: var(--omni-form-clear-icon-color, var(--omni-primary-color));
+                }
+
+                .clear-icon,
+                ::slotted([slot='clear']){
+                    width: var(--omni-form-clear-icon-width, 20px);
+                    cursor: pointer;
+                }
 
                 slot[name='prefix'],
                 slot[name='suffix'],
@@ -356,6 +407,7 @@ export class OmniFormElement extends OmniElement {
                     ${this.renderLabel()} 
                     ${this.renderContent()} 
                     <slot name="suffix"></slot>
+                    ${this.renderClear()}
                     ${this.renderControl()} ${this.renderPicker()}
                 </div>
                 ${this.renderHint()} ${this.renderError()}
@@ -396,5 +448,21 @@ export class OmniFormElement extends OmniElement {
 
     protected renderError() {
         return html`${this.error ? html`<div class="error-label">${this.error}</div>` : nothing} `;
+    }
+
+    protected renderClear(): typeof nothing | TemplateResult {
+        return html`
+        <div class="clear-control">
+            ${
+                this.clearable && this.value && !this.disabled
+                    ? html`
+            <div id="clear-click" class="clear-click" @click="${(e: MouseEvent) => this._onClearClick(e)}">
+                    <slot name="clear">
+                        <omni-clear-icon class="clear-icon"></omni-clear-icon>
+                    </slot>
+            </div>`
+                    : nothing
+            }
+        </div>`;
     }
 }

--- a/src/core/OmniFormElement.ts
+++ b/src/core/OmniFormElement.ts
@@ -133,8 +133,6 @@ export class OmniFormElement extends OmniElement {
             return e.stopImmediatePropagation();
         }
 
-        //this.value = '';
-
         this.value = null as unknown as string;
 
         // Dispatch standard DOM event to cater for single clear.
@@ -144,6 +142,9 @@ export class OmniFormElement extends OmniElement {
                 composed: true
             })
         );
+
+        // Prevent the event from bubbling up. for mobile use cases that will bring the component into focus and render the items.
+        e.stopPropagation();
     }
 
     static override get styles(): CSSResultGroup {
@@ -406,8 +407,8 @@ export class OmniFormElement extends OmniElement {
                     <slot name="prefix">${this.renderPrefix()}</slot>
                     ${this.renderLabel()} 
                     ${this.renderContent()} 
-                    <slot name="suffix"></slot>
                     ${this.renderClear()}
+                    <slot name="suffix"></slot>
                     ${this.renderControl()} ${this.renderPicker()}
                 </div>
                 ${this.renderHint()} ${this.renderError()}

--- a/src/core/OmniFormElement.ts
+++ b/src/core/OmniFormElement.ts
@@ -128,7 +128,7 @@ export class OmniFormElement extends OmniElement {
      */
     @property({ type: Boolean, reflect: true }) clearable = false;
 
-    protected _onClearClick(e: MouseEvent) {
+    protected _clearValue(e: MouseEvent) {
         if (this.disabled) {
             return e.stopImmediatePropagation();
         }
@@ -457,7 +457,7 @@ export class OmniFormElement extends OmniElement {
             ${
                 this.clearable && this.value && !this.disabled
                     ? html`
-            <div id="clear-click" class="clear-click" @click="${(e: MouseEvent) => this._onClearClick(e)}">
+            <div id="clear-click" class="clear-click" @click="${(e: MouseEvent) => this._clearValue(e)}">
                     <slot name="clear">
                         <omni-clear-icon class="clear-icon"></omni-clear-icon>
                     </slot>

--- a/src/core/OmniFormElement.ts
+++ b/src/core/OmniFormElement.ts
@@ -133,7 +133,7 @@ export class OmniFormElement extends OmniElement {
             return e.stopImmediatePropagation();
         }
 
-        this.value = null as unknown as string;
+        this.value = '';
 
         // Dispatch standard DOM event to cater for single clear.
         this.dispatchEvent(

--- a/src/core/OmniInputStories.ts
+++ b/src/core/OmniInputStories.ts
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { string } from 'yargs';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM';
 import { ComponentStoryFormat, raw } from '../utils/StoryUtils.js';
@@ -165,10 +164,10 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
     const Clearable: ComponentStoryFormat<U> = {
         render: (args: U) =>
             html`${unsafeHTML(
-                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable></${tagName}>`
+                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable=${args.clearable}></${tagName}>`
             )}`,
         name: 'Clearable',
-        description: 'Grants ability to clear the content of the component.',
+        description: 'Clear the value of the component.',
         args: {
             label: 'Clearable',
             clearable: true,
@@ -177,16 +176,16 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
         play: async (context) => {
             const input = within(context.canvasElement).getByTestId<T>('test-field');
 
-            const inputField = input.shadowRoot?.getElementById('inputField') as HTMLInputElement;
+            //const inputField = input.shadowRoot?.getElementById('inputField') as HTMLInputElement;
 
-            //Clearable class test.
+            //Clearable attribute test.
             const clearableAttribute = input.attributes.getNamedItem('clearable');
             await expect(clearableAttribute).toBeTruthy();
 
             const clearButton = input.shadowRoot?.getElementById(`clear-click`) as HTMLElement;
             await userEvent.click(clearButton);
 
-            await expect(inputField).toHaveValue('');
+            await expect(input).toHaveValue('');
         }
     };
     return Clearable;

--- a/src/core/OmniInputStories.ts
+++ b/src/core/OmniInputStories.ts
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { string } from 'yargs';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM';
 import { ComponentStoryFormat, raw } from '../utils/StoryUtils.js';
@@ -18,6 +19,7 @@ export interface BaseArgs {
     hint: string;
     error: string;
     disabled: boolean;
+    clearable: boolean;
 
     suffix: string;
     prefix: string;
@@ -154,6 +156,40 @@ export const SuffixStory = <T extends HTMLElement, U extends BaseArgs>(tagName: 
         }
     };
     return Suffix;
+};
+
+export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
+    tagName: string,
+    inputValue: string | number | string[] = 'The input value'
+) => {
+    const Clearable: ComponentStoryFormat<U> = {
+        render: (args: U) =>
+            html`${unsafeHTML(
+                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable></${tagName}>`
+            )}`,
+        name: 'Clearable',
+        description: 'Grants ability to clear the content of the component.',
+        args: {
+            label: 'Clearable',
+            clearable: true,
+            value: inputValue
+        } as U,
+        play: async (context) => {
+            const input = within(context.canvasElement).getByTestId<T>('test-field');
+
+            const inputField = input.shadowRoot?.getElementById('inputField') as HTMLInputElement;
+
+            //Clearable class test.
+            const clearableAttribute = input.attributes.getNamedItem('clearable');
+            await expect(clearableAttribute).toBeTruthy();
+
+            const clearButton = input.shadowRoot?.getElementById(`clear-click`) as HTMLElement;
+            await userEvent.click(clearButton);
+
+            await expect(inputField).toHaveValue('');
+        }
+    };
+    return Clearable;
 };
 
 export const DisabledStory = <T extends HTMLElement, U extends BaseArgs>(

--- a/src/core/OmniInputStories.ts
+++ b/src/core/OmniInputStories.ts
@@ -164,9 +164,7 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
     const Clearable: ComponentStoryFormat<U> = {
         render: (args: U) =>
             html`${unsafeHTML(
-                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable="${
-                    args.clearable
-                }"}></${tagName}>`
+                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable></${tagName}>`
             )}`,
         name: 'Clearable',
         description: 'Clear the value of the component.',

--- a/src/core/OmniInputStories.ts
+++ b/src/core/OmniInputStories.ts
@@ -164,7 +164,9 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
     const Clearable: ComponentStoryFormat<U> = {
         render: (args: U) =>
             html`${unsafeHTML(
-                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable=${args.clearable}></${tagName}>`
+                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable=${
+                    args.clearable
+                }></${tagName}>`
             )}`,
         name: 'Clearable',
         description: 'Clear the value of the component.',

--- a/src/core/OmniInputStories.ts
+++ b/src/core/OmniInputStories.ts
@@ -164,9 +164,9 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
     const Clearable: ComponentStoryFormat<U> = {
         render: (args: U) =>
             html`${unsafeHTML(
-                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable=${
+                `<${tagName} data-testid="test-field" label="${ifNotEmpty(args.label)}" value="${args.value}" clearable="${
                     args.clearable
-                }></${tagName}>`
+                }"}></${tagName}>`
             )}`,
         name: 'Clearable',
         description: 'Clear the value of the component.',
@@ -177,8 +177,6 @@ export const ClearableStory = <T extends HTMLElement, U extends BaseArgs>(
         } as U,
         play: async (context) => {
             const input = within(context.canvasElement).getByTestId<T>('test-field');
-
-            //const inputField = input.shadowRoot?.getElementById('inputField') as HTMLInputElement;
 
             //Clearable attribute test.
             const clearableAttribute = input.attributes.getNamedItem('clearable');

--- a/src/currency-field/CurrencyField.stories.ts
+++ b/src/currency-field/CurrencyField.stories.ts
@@ -44,6 +44,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
             hint="${ifNotEmpty(args.hint)}"
             error="${ifNotEmpty(args.error)}"
             ?disabled="${args.disabled}"
+            ?clearable="${args.clearable}"
             fractional-precision="${args.fractionalPrecision}"
             fractional-separator="${ifNotEmpty(args.fractionalSeparator)}"
             thousands-separator="${ifNotEmpty(args.thousandsSeparator)}"
@@ -60,6 +61,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: false,
         prefix: '',
         suffix: '',
         fractionalPrecision: 2,

--- a/src/currency-field/CurrencyField.stories.ts
+++ b/src/currency-field/CurrencyField.stories.ts
@@ -106,8 +106,6 @@ export const Interactive: ComponentStoryFormat<Args> = {
 
         await currencyField.updateComplete;
 
-        console.log('After backspacing', inputField.value);
-
         await waitFor(() => expect(inputField).toHaveValue('12,000.00'), {
             timeout: 3000
         });

--- a/src/currency-field/CurrencyField.stories.ts
+++ b/src/currency-field/CurrencyField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -150,6 +160,8 @@ export const Hint = HintStory<CurrencyField, BaseArgs>('omni-currency-field');
 export const Error_Label = ErrorStory<CurrencyField, BaseArgs>('omni-currency-field');
 
 export const Value = ValueStory<CurrencyField, BaseArgs>('omni-currency-field', '1200.50');
+
+export const Clear = ClearableStory<CurrencyField, BaseArgs>('omni-currency-field', '1200.50');
 
 export const Prefix = PrefixStory<CurrencyField, BaseArgs>('omni-currency-field');
 

--- a/src/currency-field/CurrencyField.ts
+++ b/src/currency-field/CurrencyField.ts
@@ -399,7 +399,7 @@ export class CurrencyField extends OmniFormElement {
 
     _beforeInput(e: InputEvent) {
         const input = this._inputElement as HTMLInputElement;
-        let centValue = this._convertToCents(this._inputElement?.value as string);
+        let centValue = this._convertToCents(this._inputElement?.value ? this._inputElement?.value : '0');
 
         if (centValue && input) {
             e.preventDefault();
@@ -577,7 +577,6 @@ export class CurrencyField extends OmniFormElement {
                 class=${classMap(field)}
                 id="inputField"
                 type="text"
-                maxlength="21"
                 inputmode="${this.noNativeKeyboard ? 'none' : 'decimal'}"
                 data-omni-keyboard-mode="decimal"
                 ?readOnly=${this.disabled}

--- a/src/currency-field/CurrencyField.ts
+++ b/src/currency-field/CurrencyField.ts
@@ -549,7 +549,7 @@ export class CurrencyField extends OmniFormElement {
                 }
 
                 .label {
-                    margin-left: var(--omni-currency-field-label-left-margin, 25px);
+                    margin-left: var(--omni-currency-field-label-left-margin, var(--omni-form-label-margin-left, 25px));
                 }
 
                 .currency-symbol {

--- a/src/currency-field/CurrencyField.ts
+++ b/src/currency-field/CurrencyField.ts
@@ -374,6 +374,11 @@ export class CurrencyField extends OmniFormElement {
                 );
             }
 
+            // Required to ensure that input value length does not exceed maxlength attribute value.
+            if (centValue.length > input.maxLength) {
+                centValue = centValue.substring(0, input.maxLength);
+            }
+
             // Extract the amount part of the cent value.
             const amountPart = centValue.substring(0, centValue.length - this.fractionalPrecision);
             // Extract the cents part of the cent value.
@@ -425,6 +430,11 @@ export class CurrencyField extends OmniFormElement {
                     centValue = this._convertToCents(
                         input.value.slice(0, input.selectionStart as number) + e.data + input.value.slice(input.selectionEnd as number)
                     );
+                }
+
+                // Required to ensure that input value length does not exceed maxlength attribute value.
+                if (centValue.length > input.maxLength) {
+                    centValue = centValue.substring(0, input.maxLength);
                 }
 
                 // Extract the amount part of the cent value.
@@ -579,6 +589,7 @@ export class CurrencyField extends OmniFormElement {
                 type="text"
                 inputmode="${this.noNativeKeyboard ? 'none' : 'decimal'}"
                 data-omni-keyboard-mode="decimal"
+                maxlength="15"
                 ?readOnly=${this.disabled}
                 tabindex="${this.disabled ? -1 : 0}" />
         `;

--- a/src/currency-field/CurrencyField.ts
+++ b/src/currency-field/CurrencyField.ts
@@ -401,8 +401,6 @@ export class CurrencyField extends OmniFormElement {
         const input = this._inputElement as HTMLInputElement;
         let centValue = this._convertToCents(this._inputElement?.value as string);
 
-        console.log('e.eventType', e.inputType);
-
         if (centValue && input) {
             e.preventDefault();
             /**

--- a/src/date-picker/DatePicker.stories.ts
+++ b/src/date-picker/DatePicker.stories.ts
@@ -4,7 +4,7 @@ import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { DateTime } from 'luxon';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, PrefixStory, SuffixStory, DisabledStory } from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, HintStory, ErrorStory, PrefixStory, SuffixStory, DisabledStory, ClearableStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier, querySelectorAsync } from '../utils/StoryUtils.js';
@@ -165,6 +165,8 @@ export const Label = LabelStory<DatePicker, BaseArgs>('omni-date-picker');
 export const Hint = HintStory<DatePicker, BaseArgs>('omni-date-picker');
 
 export const Error_Label = ErrorStory<DatePicker, BaseArgs>('omni-date-picker');
+
+export const Clear = ClearableStory<DatePicker, BaseArgs>('omni-date-picker', isoDate);
 
 export const Prefix = PrefixStory<DatePicker, BaseArgs>('omni-date-picker');
 

--- a/src/date-picker/DatePicker.stories.ts
+++ b/src/date-picker/DatePicker.stories.ts
@@ -35,6 +35,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
             error="${ifNotEmpty(args.error)}"
             locale="${args.locale}"
             ?disabled="${args.disabled}"
+            ?clearable="${args.clearable}"
             >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.prefix || args.suffix ? '\r\n' : nothing}</omni-date-picker

--- a/src/email-field/EmailField.stories.ts
+++ b/src/email-field/EmailField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -70,6 +80,8 @@ export const Hint = HintStory<EmailField, BaseArgs>('omni-email-field');
 export const Error_Label = ErrorStory<EmailField, BaseArgs>('omni-email-field');
 
 export const Value = ValueStory<EmailField, BaseArgs>('omni-email-field', 'johndoe@gmail.com');
+
+export const Clear = ClearableStory<EmailField, BaseArgs>('omni-email-field', 'johndoe@gmail.com');
 
 export const Prefix = PrefixStory<EmailField, BaseArgs>('omni-email-field');
 

--- a/src/email-field/EmailField.stories.ts
+++ b/src/email-field/EmailField.stories.ts
@@ -36,6 +36,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
       hint="${ifNotEmpty(args.hint)}"
       error="${ifNotEmpty(args.error)}"
       ?disabled="${args.disabled}"
+      ?clearable="${args.clearable}"
       >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.prefix || args.suffix ? '\r\n' : nothing}</omni-email-field>
@@ -47,6 +48,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: false,
         prefix: '',
         suffix: ''
     },

--- a/src/keyboard/Keyboard.ts
+++ b/src/keyboard/Keyboard.ts
@@ -581,12 +581,16 @@ export class Keyboard extends OmniElement {
                     }
                     if (!allowContinue) {
                         this.target.dispatchEvent(new KeyboardEvent('keyup', keyInfo));
+                        this.target.focus();
+                        this.requestUpdate();
                         return;
                     }
                     const old = this.target.value;
 
                     if (selection.start === 0) {
                         // Nothing to backspace
+                        this.target.focus();
+                        this.requestUpdate();
                         return;
                     }
 
@@ -653,6 +657,7 @@ export class Keyboard extends OmniElement {
                     );
 
                     // Re-render for the changes to be visible
+                    this.target.focus();
                     this.requestUpdate();
                     return;
                 }
@@ -694,6 +699,8 @@ export class Keyboard extends OmniElement {
                 }
                 if (!allowContinue) {
                     this.target.dispatchEvent(new KeyboardEvent('keyup', keyInfo));
+                    this.target.focus();
+                    this.requestUpdate();
                     return;
                 }
 

--- a/src/number-field/NumberField.stories.ts
+++ b/src/number-field/NumberField.stories.ts
@@ -36,6 +36,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
       hint="${ifNotEmpty(args.hint)}"
       error="${ifNotEmpty(args.error)}"
       ?disabled="${args.disabled}"
+      ?clearable="${args.clearable}"
       >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.prefix || args.suffix ? '\r\n' : nothing}</omni-number-field>

--- a/src/number-field/NumberField.stories.ts
+++ b/src/number-field/NumberField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -72,6 +82,8 @@ export const Hint = HintStory<NumberField, BaseArgs>('omni-number-field');
 export const Error_Label = ErrorStory<NumberField, BaseArgs>('omni-number-field');
 
 export const Value = ValueStory<NumberField, BaseArgs>('omni-number-field', 123);
+
+export const Clear = ClearableStory<NumberField, BaseArgs>('omni-number-field', 123);
 
 export const Prefix = PrefixStory<NumberField, BaseArgs>('omni-number-field');
 

--- a/src/password-field/PasswordField.stories.ts
+++ b/src/password-field/PasswordField.stories.ts
@@ -43,7 +43,8 @@ export const Interactive: ComponentStoryFormat<Args> = {
       value="${args.value}"
       hint="${ifNotEmpty(args.hint)}"
       error="${ifNotEmpty(args.error)}"
-      ?disabled="${args.disabled}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
+      ?disabled="${args.disabled}"
+      ?clearable="${args.clearable}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.hide ? html`${'\r\n'}${unsafeHTML(assignToSlot('hide', args.hide))}` : nothing}${
         args.show ? html`${'\r\n'}${unsafeHTML(assignToSlot('show', args.show))}` : nothing
@@ -56,6 +57,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: false,
         prefix: '',
         suffix: '',
         hide: '',

--- a/src/password-field/PasswordField.stories.ts
+++ b/src/password-field/PasswordField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -96,6 +106,8 @@ export const Hint = HintStory<PasswordField, BaseArgs>('omni-password-field');
 export const Error_Label = ErrorStory<PasswordField, BaseArgs>('omni-password-field');
 
 export const Value = ValueStory<PasswordField, BaseArgs>('omni-password-field', 'Password123');
+
+export const Clear = ClearableStory<PasswordField, BaseArgs>('omni-password-field', 'Password123');
 
 export const Prefix = PrefixStory<PasswordField, BaseArgs>('omni-password-field');
 

--- a/src/pin-field/PinField.stories.ts
+++ b/src/pin-field/PinField.stories.ts
@@ -153,6 +153,8 @@ export const Error_Label = ErrorStory<PinField, BaseArgs>('omni-pin-field');
 
 export const Value = ValueStory<PinField, BaseArgs>('omni-pin-field', 1234);
 
+export const Clear = ClearableStory<PinField, BaseArgs>('omni-pin-field', 1234);
+
 export const Prefix = PrefixStory<PinField, BaseArgs>('omni-pin-field');
 
 export const Suffix = SuffixStory<PinField, BaseArgs>('omni-pin-field');

--- a/src/pin-field/PinField.stories.ts
+++ b/src/pin-field/PinField.stories.ts
@@ -46,7 +46,8 @@ export const Interactive: ComponentStoryFormat<Args> = {
       max-length=${args.maxLength}
       hint="${ifNotEmpty(args.hint)}"
       error="${ifNotEmpty(args.error)}"
-      ?disabled="${args.disabled}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
+      ?disabled="${args.disabled}"
+      ?clearable="${args.clearable}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.hide ? html`${'\r\n'}${unsafeHTML(assignToSlot('hide', args.hide))}` : nothing}${
         args.show ? html`${'\r\n'}${unsafeHTML(assignToSlot('show', args.show))}` : nothing
@@ -59,6 +60,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: false,
         prefix: '',
         suffix: '',
         hide: '',

--- a/src/pin-field/PinField.stories.ts
+++ b/src/pin-field/PinField.stories.ts
@@ -5,7 +5,17 @@ import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';

--- a/src/search-field/SearchField.stories.ts
+++ b/src/search-field/SearchField.stories.ts
@@ -46,7 +46,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         hint: '',
         error: '',
         disabled: false,
-        clearable: true,
+        clearable: false,
         prefix: '',
         suffix: ''
     },

--- a/src/search-field/SearchField.stories.ts
+++ b/src/search-field/SearchField.stories.ts
@@ -71,13 +71,6 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         await waitFor(() => expect(interaction).toBeCalledTimes(value.length), {
             timeout: 3000
         });
-
-        const clearButton = searchField.shadowRoot?.getElementById(`clear-click`) as HTMLElement;
-        await userEvent.click(clearButton);
-
-        await waitFor(() => expect(inputField).toHaveValue(''), {
-            timeout: 3000
-        });
     }
 };
 

--- a/src/search-field/SearchField.stories.ts
+++ b/src/search-field/SearchField.stories.ts
@@ -64,7 +64,6 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         const value = 'Batman';
         await userEvent.type(inputField, value);
 
-        // TODO: Fix race conditions in tests
         await waitFor(() => expect(inputField).toHaveValue(value), {
             timeout: 3000
         });

--- a/src/search-field/SearchField.stories.ts
+++ b/src/search-field/SearchField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    ClearableStory,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -24,7 +34,8 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
             value="${args.value}"
             hint="${ifNotEmpty(args.hint)}"
             error="${ifNotEmpty(args.error)}"
-            ?disabled="${args.disabled}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
+            ?disabled="${args.disabled}"
+            ?clearable="${args.clearable}">${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.prefix || args.suffix ? '\r\n' : nothing}</omni-search-field>
     `,
@@ -35,6 +46,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: true,
         prefix: '',
         suffix: ''
     },
@@ -53,18 +65,14 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         await userEvent.type(inputField, value);
 
         // TODO: Fix race conditions in tests
-        if (navigator.userAgent === 'Test Runner') {
-            console.log('CICD Test - Not Visual');
-        } else {
-            await waitFor(() => expect(inputField).toHaveValue(value), {
-                timeout: 3000
-            });
-            await waitFor(() => expect(interaction).toBeCalledTimes(value.length), {
-                timeout: 3000
-            });
-        }
+        await waitFor(() => expect(inputField).toHaveValue(value), {
+            timeout: 3000
+        });
+        await waitFor(() => expect(interaction).toBeCalledTimes(value.length), {
+            timeout: 3000
+        });
 
-        const clearButton = searchField.shadowRoot?.getElementById(`control`) as HTMLElement;
+        const clearButton = searchField.shadowRoot?.getElementById(`clear-click`) as HTMLElement;
         await userEvent.click(clearButton);
 
         await waitFor(() => expect(inputField).toHaveValue(''), {
@@ -80,6 +88,8 @@ export const Hint = HintStory<SearchField, BaseArgs>('omni-search-field');
 export const ErrorLabel = ErrorStory<SearchField, BaseArgs>('omni-search-field');
 
 export const Value = ValueStory<SearchField, BaseArgs>('omni-search-field');
+
+export const Clear = ClearableStory<SearchField, BaseArgs>('omni-search-field', 'Clear my name');
 
 export const Prefix = PrefixStory<SearchField, BaseArgs>('omni-search-field');
 

--- a/src/search-field/SearchField.ts
+++ b/src/search-field/SearchField.ts
@@ -85,22 +85,6 @@ export class SearchField extends OmniFormElement {
         this.value = input?.value;
     }
 
-    async _clearField(e: MouseEvent) {
-        if (this.disabled) {
-            return e.stopImmediatePropagation();
-        }
-
-        this.value = '';
-
-        // Dispatch standard DOM event to cater for single clear.
-        this.dispatchEvent(
-            new Event('change', {
-                bubbles: true,
-                composed: true
-            })
-        );
-    }
-
     static override get styles() {
         return [
             super.styles,
@@ -134,24 +118,6 @@ export class SearchField extends OmniFormElement {
                     color: var(--omni-search-field-error-font-color);
                 }
 
-                .control {
-                    display: flex;
-                  
-                    margin-right: var(--omni-search-field-control-margin-right, 10px);
-                    margin-left: var(--omni-search-field-control-margin-left, 10px);
-                    width: var(--omni-search-field-control-width, 20px);
-                }
-
-                .clear-icon {
-                    fill: var(--omni-search-field-clear-icon-color, var(--omni-primary-color));
-                }
-
-                .clear-icon,
-                ::slotted([slot='clear']){
-                    width: var(--omni-search-field-clear-icon-width, 20px);
-                    cursor: pointer;
-                }
-
                 .search-icon {
                     fill: var(--omni-search-field-search-icon-color, var(--omni-primary-color));
                     width: var(--omni-search-field-search-icon-width, 20px);   
@@ -176,14 +142,6 @@ export class SearchField extends OmniFormElement {
 
     protected override renderPrefix() {
         return html`<omni-search-icon class="search-icon"></omni-search-icon>`;
-    }
-
-    protected override renderControl() {
-        return html`
-            <div id="control" class="control" @click="${(e: MouseEvent) => this._clearField(e)}">
-                ${this.value ? html`<slot name="clear"><omni-clear-icon class="clear-icon"></omni-clear-icon></slot>` : ``}
-            </div>
-        `;
     }
 
     protected override renderContent() {

--- a/src/select/Select.stories.ts
+++ b/src/select/Select.stories.ts
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import { LabelStory, BaseArgs, ClearableStory, HintStory, ErrorStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
 import { RenderFunction } from '../render-element/RenderElement.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
@@ -367,6 +367,8 @@ export const Label = LabelStory<Select, BaseArgs>('omni-select');
 export const Hint = HintStory<Select, BaseArgs>('omni-select');
 
 export const Error_Label = ErrorStory<Select, BaseArgs>('omni-select');
+
+export const Clear = ClearableStory<Select, BaseArgs>('omni-select');
 
 export const Prefix = PrefixStory<Select, BaseArgs>('omni-select');
 

--- a/src/select/Select.stories.ts
+++ b/src/select/Select.stories.ts
@@ -62,6 +62,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
             .renderItem="${args.renderItem}"
             idField="${args.idField}"
             ?disabled="${args.disabled}"
+            ?clearable="${args.clearable}"
             empty-message="${args.emptyMessage}"
             >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
@@ -78,6 +79,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: false,
         prefix: '',
         suffix: '',
         items: displayItems as Record<string, unknown>[],

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -178,8 +178,21 @@ export class Select extends OmniFormElement {
     _togglePopup() {
         if (this._popUp) {
             this._popUp = false;
+            if(this._isMobile){
+                //this._pickerContainer?.close();
+                const pickerDialog = this.renderRoot.querySelector<HTMLDialogElement>('#picker-dialog');
+                if(pickerDialog){
+                    pickerDialog.close();
+                }
+            }
         } else {
             this._popUp = true;
+            if(this._isMobile) {
+                const pickerDialog = this.renderRoot.querySelector<HTMLDialogElement>('#picker-dialog');
+                if(pickerDialog){
+                    pickerDialog.showModal();
+                }
+            }
         }
     }
 
@@ -369,6 +382,23 @@ export class Select extends OmniFormElement {
                         border-top-left-radius: var(--omni-select-mobile-items-container-border-top-left-radius, 10px);
                         border-top-right-radius: var(--omni-select-mobile-items-container-border-top-right-radius, 10px);
                     }
+
+                    .picker-dialog {
+                        position: fixed;
+                        top: inherit;
+                        width: 100%;
+                        margin: unset;
+                        border-style: none;
+                        padding: unset;
+                        left: var(--omni-date-picker-mobile-picker-dialog-left, 0px);
+                        right: var(--omni-date-picker-mobile-picker-dialog-right, 0px);
+                        bottom: var(--omni-date-picker-mobile-picker-dialog-bottom, 0px);
+                    }
+                    
+                    .picker-dialog:modal{
+                        max-width: 100%;
+                        overflow: none;
+                    }
                 }
 
                 /* Should only display for mobile rendering */
@@ -462,16 +492,24 @@ export class Select extends OmniFormElement {
     }
 
     protected override renderPicker() {
+        if(this._isMobile){
+            return html `
+            <dialog id="picker-dialog" class="picker-dialog">
+                ${this._isMobile && this.label ? html`<div class="header">${this.label}</div>` : nothing}
+                <div ${ref(this._itemsMaxHeightChange)} id="items" class="items"> ${until(this._renderOptions(),html`<div>${this.renderLoading()}</div>`)} 
+                </div>
+            </dialog>
+            `
+        }
+        
         if (!this._popUp) {
             return nothing;
         }
         return html`
             <div id="items-container" class="items-container ${this._bottomOfViewport ? `bottom` : ``}">
                 ${this._isMobile && this.label ? html`<div class="header">${this.label}</div>` : nothing}
-                <div ${ref(this._itemsMaxHeightChange)} id="items" class="items"> ${until(
-            this._renderOptions(),
-            html`<div>${this.renderLoading()}</div>`
-        )} </div>
+                <div ${ref(this._itemsMaxHeightChange)} id="items" class="items"> ${until(this._renderOptions(),html`<div>${this.renderLoading()}</div>`)} 
+                </div>
             </div>
         `;
     }

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -161,14 +161,6 @@ export class Select extends OmniFormElement {
     }
 
     _inputClick(e: Event) {
-        /*
-        const itemsContainer = this.renderRoot.querySelector<HTMLDivElement>('#items-container');
-        const itemsDialog = this.renderRoot.querySelector<HTMLDialogElement>('#items-dialog');
-        
-        //Check that the pickerContainer or pickerDialog is not loaded 
-        if ((!e.composedPath() || !(itemsContainer || itemsDialog) || !(e.composedPath().includes(itemsContainer as Element) || e.composedPath().includes(itemsDialog as Element)))) {
-            this._togglePopup();
-        }*/
         this._togglePopup();
     }
 
@@ -198,7 +190,6 @@ export class Select extends OmniFormElement {
         if (this._popUp) {
             this._popUp = false;
             if (this._isMobile) {
-                //this._pickerContainer?.close();
                 const itemsDialog = this.renderRoot.querySelector<HTMLDialogElement>('#items-dialog');
                 if (itemsDialog) {
                     itemsDialog.close();

--- a/src/text-field/TextField.stories.ts
+++ b/src/text-field/TextField.stories.ts
@@ -48,7 +48,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         hint: '',
         error: '',
         disabled: false,
-        clearable: true,
+        clearable: false,
         prefix: '',
         suffix: ''
     },

--- a/src/text-field/TextField.stories.ts
+++ b/src/text-field/TextField.stories.ts
@@ -4,7 +4,17 @@ import { setUIValueClean } from '@testing-library/user-event/dist/esm/document/U
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { LabelStory, BaseArgs, HintStory, ErrorStory, DisabledStory, ValueStory, PrefixStory, SuffixStory } from '../core/OmniInputStories.js';
+import {
+    LabelStory,
+    BaseArgs,
+    HintStory,
+    ErrorStory,
+    DisabledStory,
+    ValueStory,
+    PrefixStory,
+    SuffixStory,
+    ClearableStory
+} from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
 import { assignToSlot, ComponentStoryFormat, CSFIdentifier } from '../utils/StoryUtils.js';
@@ -26,6 +36,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
       hint="${ifNotEmpty(args.hint)}"
       error="${ifNotEmpty(args.error)}"
       ?disabled="${args.disabled}"
+      ?clearable="${args.clearable}"
       >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
     }${args.prefix || args.suffix ? '\r\n' : nothing}</omni-text-field>
@@ -37,6 +48,7 @@ export const Interactive: ComponentStoryFormat<BaseArgs> = {
         hint: '',
         error: '',
         disabled: false,
+        clearable: true,
         prefix: '',
         suffix: ''
     },
@@ -68,6 +80,8 @@ export const Hint = HintStory<TextField, BaseArgs>('omni-text-field');
 export const Error_Label = ErrorStory<TextField, BaseArgs>('omni-text-field');
 
 export const Value = ValueStory<TextField, BaseArgs>('omni-text-field');
+
+export const Clear = ClearableStory<TextField, BaseArgs>('omni-text-field');
 
 export const Prefix = PrefixStory<TextField, BaseArgs>('omni-text-field');
 

--- a/src/text-field/TextField.ts
+++ b/src/text-field/TextField.ts
@@ -67,6 +67,7 @@ export class TextField extends OmniFormElement {
     _keyInput() {
         const input = this._inputElement;
         this.value = input?.value;
+        this.requestUpdate();
     }
 
     static override get styles() {


### PR DESCRIPTION
### Description:

(*Link to bug/feature from [Issues](../issues) and how you resolve it*)

closes https://github.com/capitec/omni-components/issues/99
closes https://github.com/capitec/omni-components/issues/80

- Introduce clearable attribute to OmniFormElement to introduce functionality to clear components value that inherit from the OmniFormElement base class.
- Introduce dialog to Date picker and Select components for mobile modes this introduces a default overlay.
- Resolve issue with Keyboard component not updating value for Currency field correctly.
- Updated stories of components to have a Clear story.
- Resolved the positioning of the Color field component label.
- Removed clear capability on the Search field component.
- Resolved label position of Currency field prefix story.
- Added max length implementation to the currency field to limit the value of the input to a trillion cent value

### Screenshots (if appropriate):

**Test results**

![image](https://user-images.githubusercontent.com/22874454/234306018-1285b12c-15d6-4dd1-a741-560e54e4c970.png)


### Clear functionality

- Changes to the attribute name or story adjustments are welcomed

Note this is illustrated for components that work with different datatypes.

**Text Field**

![Text field clear](https://user-images.githubusercontent.com/22874454/234283966-eb2491f3-5143-4257-a5e0-2886f20df613.gif)

**Date Picker**

![Date picker clear](https://user-images.githubusercontent.com/22874454/234284221-3d601a87-0883-4c04-9ccd-b4bb09201b59.gif)

**Select**

![Select clear](https://user-images.githubusercontent.com/22874454/234284809-2cd1af14-90fa-4d6a-bcfd-846b2278e191.gif)


**Number Field**

![Number field clear](https://user-images.githubusercontent.com/22874454/234284424-c8e1adcf-4fc0-477a-a2e6-12c9e5a7a042.gif)


### Color Field

**Before** 
![image](https://user-images.githubusercontent.com/22874454/234281806-6c63da83-0624-4b41-8a7e-5adae22b6b7d.png)

**After**
![image](https://user-images.githubusercontent.com/22874454/234281934-64623cb6-eb97-41ca-a679-aac56f2b46cd.png)

### Dialogs for Date picker and Select

**Date Picker Component**

**Before** 

![Date picker old implementation](https://user-images.githubusercontent.com/22874454/234300396-e5f90fca-ab2f-40b4-8531-a209b2802f78.gif)


**After**

![Date picker dialog](https://user-images.githubusercontent.com/22874454/234299619-f85caf08-9f6e-4d9f-b84d-b1998d3f5e65.gif)

**Select Component**

**Before**

![Select old implementation](https://user-images.githubusercontent.com/22874454/234300454-64e8e21f-cea6-4104-8b37-7ac827af1103.gif)


**After**

![Select dialog](https://user-images.githubusercontent.com/22874454/234299639-44c853dc-56e0-4641-90cc-5ec38574cd3c.gif)


### Max length for Currency field

Before 

![before maxlength](https://user-images.githubusercontent.com/22874454/234555598-6a2dac7a-9114-4597-ab43-a5051a3c725e.gif)

After

![after maxlength](https://user-images.githubusercontent.com/22874454/234555756-1d46d63c-d31d-4394-a78d-41e2a89e8476.gif)

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
