### PR TITLE
Added Prism highlighting for bash in docs

### DIFF
--- a/.tooling/eleventy/includes/base.njk
+++ b/.tooling/eleventy/includes/base.njk
@@ -34,6 +34,7 @@
     <link rel="stylesheet preload" href="https://fonts.googleapis.com/css?family=Hind Vadodara"  as="style">
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-jsx.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
     <link id="theme-styles-link" rel="stylesheet preload" href="{{ './assets/css/themes.css' | url }}" as="style">
     <style id="theme-styles"></style>
     <script src="https://cdn.jsdelivr.net/npm/cssbeautify@0.3.1/cssbeautify.js"></script>

--- a/.tooling/readme/blueprint.md
+++ b/.tooling/readme/blueprint.md
@@ -57,7 +57,7 @@ Core features of the library include:
 1️⃣ &nbsp; Install {{ template:projectName }} in your project.
 
 ```bash
-npm install {{ pkg.name }}
+npm install '{{ pkg.name }}'
 ```
 
 2️⃣ &nbsp; Import the components you require. See [`INSTALLATION.md`](./INSTALLATION.md) for more detail.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -18,7 +18,7 @@ The easiest way to install Omni Components is with the CDN:
 You can also install Omni Components locally with the following command:
 
 ```bash
-npm install @capitec/omni-components
+npm install '@capitec/omni-components'
 ```
 
 With the latest package installed from NPM, [you can use a bundler](#bundling-). The ESM package used for [CDN Installation](#cdn-installation-(easiest)-) has its dependencies bundled already which allows it to be used without the need to install dependencies. However when using the local installation from NPM, the dependencies need to be provided externally, or you would need to [bundle the dependencies](#bundling-).
@@ -52,7 +52,7 @@ Omni Components is distributed as a collection of standard ES modules that [all 
 To use Omni Components with a bundler, first install it from NPM along with your bundler of choice:
 
 ```bash
-npm install @capitec/omni-components
+npm install '@capitec/omni-components'
 ```
 
 > 💡 Using a bundler will allow for optimal [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking), which will ensure the smallest size and most efficient usage. Our [starter templates](#starter-templates-) already provide this for you!
@@ -69,7 +69,7 @@ Omni Components provides a separate package with each web component wrapped into
 You can install Omni Components for React locally with the following command:
 
 ```bash
-npm install @capitec/omni-components-react
+npm install '@capitec/omni-components-react'
 ```
 
 Or you can use Omni Components for React directly via a CDN:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Core features of the library include:
 1️⃣ &nbsp; Install Omni Components in your project.
 
 ```bash
-npm install @capitec/omni-components
+npm install '@capitec/omni-components'
 ```
 
 2️⃣ &nbsp; Import the components you require. See [`INSTALLATION.md`](./INSTALLATION.md) for more detail.
@@ -191,11 +191,11 @@ Control that allows an action to be executed.
 
 </td></tr><tr><td>
 
-[omni-calendar](src/calendar/README.md)
+[omni-chip](src/chip/README.md)
 
 </td><td>
 
-Calendar component to set specific date.
+Control that can be used for input, setting attributes, or performing actions.
 
 </td></tr><tr><td>
 
@@ -207,11 +207,11 @@ Control that allows a selection to be made.
 
 </td></tr><tr><td>
 
-[omni-chip](src/chip/README.md)
+[omni-calendar](src/calendar/README.md)
 
 </td><td>
 
-Control that can be used for input, setting attributes, or performing actions.
+Calendar component to set specific date.
 
 </td></tr><tr><td>
 
@@ -247,19 +247,19 @@ Email input control, used in forms for input validation and to display correct v
 
 </td></tr><tr><td>
 
-[omni-hyperlink](src/hyperlink/README.md)
-
-</td><td>
-
-Control to indicate an action to be executed. Typically used for navigational purposes.
-
-</td></tr><tr><td>
-
 [omni-icon](src/icon/README.md)
 
 </td><td>
 
 Component that displays an icon.
+
+</td></tr><tr><td>
+
+[omni-hyperlink](src/hyperlink/README.md)
+
+</td><td>
+
+Control to indicate an action to be executed. Typically used for navigational purposes.
 
 </td></tr><tr><td>
 
@@ -495,19 +495,19 @@ Input control to enter a single line of numbers.
 
 </td></tr><tr><td>
 
-[omni-password-field](src/password-field/README.md)
-
-</td><td>
-
-Password input control.
-
-</td></tr><tr><td>
-
 [omni-pin-field](src/pin-field/README.md)
 
 </td><td>
 
 Input control to enter a masked numeric value.
+
+</td></tr><tr><td>
+
+[omni-password-field](src/password-field/README.md)
+
+</td><td>
+
+Password input control.
 
 </td></tr><tr><td>
 


### PR DESCRIPTION
### Description:

Added Prism highlighting for bash in docs

### Screenshots (if appropriate):

Old:
![image](https://user-images.githubusercontent.com/16349308/235621649-111944db-629f-4e86-b4b6-85331dda6fd3.png)

New with highlighting:
![image](https://user-images.githubusercontent.com/16349308/235621795-c3315d30-73c7-4dca-b71e-c6ac60539049.png)


### All Submissions:

* [X] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [X] I have added an explanation of what my changes do and why I would like to include them.
* [X] I have written new tests for my core changes, as applicable.
* [X] I have successfully ran tests with my changes locally.
* [X] I have added/updated docs, as applicable.
