### PR TITLE
Add `min-date` and `max-date` to `omni-calendar` and `omni-date-picker`

### DIFF
--- a/src/calendar/Calendar.stories.ts
+++ b/src/calendar/Calendar.stories.ts
@@ -17,6 +17,8 @@ export default {
 interface Args {
     locale: string;
     value: string;
+    minDate?: string;
+    maxDate?: string;
 }
 
 const localDate = DateTime.local().plus({ days: 1 });
@@ -28,13 +30,17 @@ export const Interactive: ComponentStoryFormat<Args> = {
         data-testid="test-calendar"
         locale="${ifNotEmpty(args.locale)}"
         value="${ifNotEmpty(args.value)}"
+        min-date="${ifNotEmpty(args.minDate)}"
+        max-date="${ifNotEmpty(args.maxDate)}"
     >       
     </omni-calendar>
     `,
     name: 'Interactive',
     args: {
         locale: '',
-        value: ''
+        value: '',
+        maxDate: '',
+        minDate: ''
     } as Args,
     play: async (context) => {
         const calendar = within(context.canvasElement).getByTestId<Calendar>('test-calendar');
@@ -123,5 +129,111 @@ const App = () => <OmniCalendar${args.locale ? ` locale='${args.locale}'` : ''}/
     play: async (context) => {
         const calendar = within(context.canvasElement).getByTestId<Calendar>('test-calendar');
         await expect(calendar).toHaveAttribute('locale', 'ja-JP');
+    }
+};
+
+export const Min_Date: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+    <omni-calendar
+        data-testid="test-calendar"
+        min-date="${ifNotEmpty(args.minDate)}"
+        value="${ifNotEmpty(args.value)}"
+        >
+    </omni-calendar>
+    `,
+    frameworkSources: [
+        {
+            framework: 'React',
+            load: (args) => `import { OmniCalendar } from "@capitec/omni-components-react/calendar";
+
+const App = () => <OmniCalendar${args.minDate ? ` min-date='${args.minDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+        }
+    ],
+    name: 'Min Date',
+    description: 'Limit the Calendar to only have selectable dates after and including the specified min-date.',
+    args: {
+        minDate: '2023-04-14',
+        value: '2023-04-15'
+    } as Args,
+    play: async (context) => {
+        const calendar = within(context.canvasElement).getByTestId<Calendar>('test-calendar');
+        calendar.value = context.args.value;
+        await expect(calendar).toHaveAttribute('min-date', context.args.minDate);
+
+        const days = Array.from(calendar.shadowRoot?.querySelectorAll('.day') as NodeListOf<Element>);
+        const isExcluded = days[17];
+
+        await expect(isExcluded).toHaveClass('excluded');
+
+        const preValue = calendar.value;
+
+        await userEvent.click(isExcluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(calendar).toHaveValue(preValue);
+
+        const isIncluded = days[20];
+
+        await expect(isIncluded).not.toHaveClass('excluded');
+
+        await userEvent.click(isIncluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(calendar).not.toHaveValue(preValue);
+    }
+};
+
+export const Max_Date: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+    <omni-calendar
+        data-testid="test-calendar"
+        max-date="${ifNotEmpty(args.maxDate)}"
+        value="${ifNotEmpty(args.value)}"
+        >
+    </omni-calendar>
+    `,
+    frameworkSources: [
+        {
+            framework: 'React',
+            load: (args) => `import { OmniCalendar } from "@capitec/omni-components-react/calendar";
+
+const App = () => <OmniCalendar${args.maxDate ? ` max-date='${args.maxDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+        }
+    ],
+    name: 'Max Date',
+    description: 'Limit the Calendar to only have selectable dates before and including the specified max-date.',
+    args: {
+        maxDate: '2023-04-14',
+        value: '2023-04-13'
+    } as Args,
+    play: async (context) => {
+        const calendar = within(context.canvasElement).getByTestId<Calendar>('test-calendar');
+        calendar.value = context.args.value;
+        await expect(calendar).toHaveAttribute('max-date', context.args.maxDate);
+
+        const days = Array.from(calendar.shadowRoot?.querySelectorAll('.day') as NodeListOf<Element>);
+        const isExcluded = days[20];
+
+        await expect(isExcluded).toHaveClass('excluded');
+
+        const preValue = calendar.value;
+
+        await userEvent.click(isExcluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(calendar).toHaveValue(preValue);
+
+        const isIncluded = days[15];
+
+        await expect(isIncluded).not.toHaveClass('excluded');
+
+        await userEvent.click(isIncluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(calendar).not.toHaveValue(preValue);
     }
 };

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -19,7 +19,7 @@ import '../icons/ChevronRight.icon.js';
  * ```html
  * <omni-calendar
  *   value="2023-02-23"
-*    min-date="2023-02-07"
+ *    min-date="2023-02-07"
  *   max-date="2023-02-25"
  *   locale="en-US">
  * </omni-calendar>

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -19,6 +19,8 @@ import '../icons/ChevronRight.icon.js';
  * ```html
  * <omni-calendar
  *   value="2023-02-23"
+*    min-date="2023-02-07"
+ *   max-date="2023-02-25"
  *   locale="en-US">
  * </omni-calendar>
  * ```
@@ -149,6 +151,18 @@ export class Calendar extends OmniElement {
     @property({ type: String, reflect: true }) locale: string = this.defaultLocale;
 
     /**
+     * The minimum date inclusively allowed to be selected.
+     * @attr [min-date]
+     */
+    @property({ type: String, attribute: 'min-date', reflect: true }) minDate?: string;
+
+    /**
+     * The maximum date inclusively allowed to be selected.
+     * @attr [max-date]
+     */
+    @property({ type: String, attribute: 'max-date', reflect: true }) maxDate?: string;
+
+    /**
      * The value of the Calendar component
      * @attr
      */
@@ -202,6 +216,11 @@ export class Calendar extends OmniElement {
     _dateSelect(e: Event, date: DateTime) {
         e.preventDefault();
         e.stopImmediatePropagation();
+
+        if ((e.target as Element)?.classList?.contains('excluded')) {
+            // If an excluded date was selected (programmatically still possible, pointer-events: none only prevents physical clicks), ignore selection
+            return;
+        }
 
         this.date = date.setLocale(this.locale);
         this.value = this.date.toISODate();
@@ -307,6 +326,22 @@ export class Calendar extends OmniElement {
         }
 
         return decadeArray;
+    }
+
+    private _isOutOfRange(date: DateTime): boolean {
+        if (this.minDate) {
+            const minDateValue = DateTime.fromISO(this.minDate);
+            if (date < minDateValue) {
+                return true;
+            }
+        }
+        if (this.maxDate) {
+            const maxDateValue = DateTime.fromISO(this.maxDate);
+            if (date > maxDateValue) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static override get styles() {
@@ -688,7 +723,7 @@ export class Calendar extends OmniElement {
                 this.date.hasSame(date, 'day') &&
                 date.month === this._selectedMonth &&
                 date.year === this._selectedYear,
-            excluded: date.month !== this._selectedMonth
+            excluded: date.month !== this._selectedMonth || this._isOutOfRange(date)
         };
 
         return html`

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -19,7 +19,7 @@ import '../icons/ChevronRight.icon.js';
  * ```html
  * <omni-calendar
  *   value="2023-02-23"
- *    min-date="2023-02-07"
+ *   min-date="2023-02-07"
  *   max-date="2023-02-25"
  *   locale="en-US">
  * </omni-calendar>

--- a/src/date-picker/DatePicker.stories.ts
+++ b/src/date-picker/DatePicker.stories.ts
@@ -1,9 +1,10 @@
-import { within } from '@testing-library/dom';
+import { waitFor, within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import * as jest from 'jest-mock';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { DateTime } from 'luxon';
+import { Calendar } from '../calendar/Calendar.js';
 import { LabelStory, BaseArgs, HintStory, ErrorStory, PrefixStory, SuffixStory, DisabledStory, ClearableStory } from '../core/OmniInputStories.js';
 import { ifNotEmpty } from '../utils/Directives.js';
 import expect from '../utils/ExpectDOM.js';
@@ -19,6 +20,8 @@ export default {
 
 interface Args extends BaseArgs {
     locale: string;
+    minDate?: string;
+    maxDate?: string;
 }
 const localDate = DateTime.local();
 const isoDate = localDate.toISODate();
@@ -35,6 +38,8 @@ export const Interactive: ComponentStoryFormat<Args> = {
             locale="${args.locale}"
             ?disabled="${args.disabled}"
             ?clearable="${args.clearable}"
+            min-date="${ifNotEmpty(args.minDate)}"
+            max-date="${ifNotEmpty(args.maxDate)}"
             >${args.prefix ? html`${'\r\n'}${unsafeHTML(assignToSlot('prefix', args.prefix))}` : nothing}
             ${args.clear ? html`${'\r\n'}${unsafeHTML(assignToSlot('clear', args.clear))}` : nothing}${
         args.suffix ? html`${'\r\n'}${unsafeHTML(assignToSlot('suffix', args.suffix))}` : nothing
@@ -51,7 +56,10 @@ export const Interactive: ComponentStoryFormat<Args> = {
         prefix: '',
         suffix: '',
         clear: '',
-        locale: 'en-us'
+        locale: 'en-us',
+        maxDate: '',
+        minDate: '',
+        clearable: false,
     } as Args,
     play: async (context) => {
         const datePicker = within(context.canvasElement).getByTestId<DatePicker>('test-date-picker');
@@ -174,6 +182,130 @@ const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${
 
         await expect(controlLabel).toHaveTextContent(localDate.monthLong + ' ' + localDate.year);
         await userEvent.click(datePicker);
+    }
+};
+
+export const Min_Date: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+    <omni-date-picker
+        data-testid="test-date-picker"
+        label="${ifNotEmpty(args.label)}"
+        min-date="${ifNotEmpty(args.minDate)}"
+        value="${ifNotEmpty(args.value)}"
+    >
+    </omni-date-picker>
+    `,
+    frameworkSources: [
+        {
+            framework: 'React',
+            load: (args) => `import { OmniDatePicker } from "@capitec/omni-components-react/date-picker";
+
+const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.minDate ? ` min-date='${args.minDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+        }
+    ],
+    name: 'Min Date',
+    description: 'Limit the Date Picker to only have selectable dates after and including the specified min-date.',
+    args: {
+        minDate: '2023-04-14',
+        value: '2023-04-15'
+    } as Args,
+    play: async (context) => {
+        const datePicker = within(context.canvasElement).getByTestId<DatePicker>('test-date-picker');
+        datePicker.value = context.args.value;
+
+        await userEvent.click(datePicker);
+
+        const calendar = (await querySelectorAsync(datePicker.shadowRoot as ShadowRoot, '#calendar')) as Calendar;
+        await expect(calendar).toBeTruthy();
+      
+        await waitFor(() => expect(calendar).toHaveAttribute('min-date', context.args.minDate), {
+            timeout: 3000
+        });
+
+        const days = Array.from(calendar.shadowRoot?.querySelectorAll('.day') as NodeListOf<Element>);
+        const isExcluded = days[17];
+
+        await expect(isExcluded).toHaveClass('excluded');
+
+        const preValue = datePicker.value;
+
+        await userEvent.click(isExcluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(datePicker).toHaveValue(preValue);
+
+        const isIncluded = days[20];
+
+        await expect(isIncluded).not.toHaveClass('excluded');
+
+        await userEvent.click(isIncluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(datePicker).not.toHaveValue(preValue);
+    }
+};
+
+export const Max_Date: ComponentStoryFormat<Args> = {
+    render: (args: Args) => html`
+    <omni-date-picker
+        data-testid="test-date-picker"
+        label="${ifNotEmpty(args.label)}"
+        max-date="${ifNotEmpty(args.maxDate)}"
+        value="${ifNotEmpty(args.value)}"
+    >
+    </omni-date-picker>
+    `,
+    frameworkSources: [
+        {
+            framework: 'React',
+            load: (args) => `import { OmniDatePicker } from "@capitec/omni-components-react/date-picker";
+
+const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.maxDate ? ` max-date='${args.maxDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+        }
+    ],
+    name: 'Max Date',
+    description: 'Limit the Date Picker to only have selectable dates before and including the specified max-date.',
+    args: {
+        maxDate: '2023-04-14',
+        value: '2023-04-13'
+    } as Args,
+    play: async (context) => {
+        const datePicker = within(context.canvasElement).getByTestId<DatePicker>('test-date-picker');
+        datePicker.value = context.args.value;
+        
+        await userEvent.click(datePicker);
+
+        const calendar = (await querySelectorAsync(datePicker.shadowRoot as ShadowRoot, '#calendar')) as Calendar;
+        await expect(calendar).toBeTruthy();
+      
+        await waitFor(() => expect(calendar).toHaveAttribute('max-date', context.args.maxDate), {
+            timeout: 3000
+        });
+
+        const days = Array.from(calendar.shadowRoot?.querySelectorAll('.day') as NodeListOf<Element>);
+        const isExcluded = days[20];
+
+        await expect(isExcluded).toHaveClass('excluded');
+
+        const preValue = datePicker.value;
+
+        await userEvent.click(isExcluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(datePicker).toHaveValue(preValue);
+
+        const isIncluded = days[15];
+
+        await expect(isIncluded).not.toHaveClass('excluded');
+
+        await userEvent.click(isIncluded, {
+            pointerEventsCheck: 0
+        });
+
+        await expect(datePicker).not.toHaveValue(preValue);
     }
 };
 

--- a/src/date-picker/DatePicker.stories.ts
+++ b/src/date-picker/DatePicker.stories.ts
@@ -59,7 +59,7 @@ export const Interactive: ComponentStoryFormat<Args> = {
         locale: 'en-us',
         maxDate: '',
         minDate: '',
-        clearable: false,
+        clearable: false
     } as Args,
     play: async (context) => {
         const datePicker = within(context.canvasElement).getByTestId<DatePicker>('test-date-picker');
@@ -200,7 +200,9 @@ export const Min_Date: ComponentStoryFormat<Args> = {
             framework: 'React',
             load: (args) => `import { OmniDatePicker } from "@capitec/omni-components-react/date-picker";
 
-const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.minDate ? ` min-date='${args.minDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.minDate ? ` min-date='${args.minDate}'` : ''}${
+                args.value ? ` value='${args.value}'` : ''
+            }/>;`
         }
     ],
     name: 'Min Date',
@@ -217,7 +219,7 @@ const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${
 
         const calendar = (await querySelectorAsync(datePicker.shadowRoot as ShadowRoot, '#calendar')) as Calendar;
         await expect(calendar).toBeTruthy();
-      
+
         await waitFor(() => expect(calendar).toHaveAttribute('min-date', context.args.minDate), {
             timeout: 3000
         });
@@ -262,7 +264,9 @@ export const Max_Date: ComponentStoryFormat<Args> = {
             framework: 'React',
             load: (args) => `import { OmniDatePicker } from "@capitec/omni-components-react/date-picker";
 
-const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.maxDate ? ` max-date='${args.maxDate}'` : ''}${args.value ? ` value='${args.value}'` : ''}/>;`
+const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${args.maxDate ? ` max-date='${args.maxDate}'` : ''}${
+                args.value ? ` value='${args.value}'` : ''
+            }/>;`
         }
     ],
     name: 'Max Date',
@@ -274,12 +278,12 @@ const App = () => <OmniDatePicker${args.label ? ` label='${args.label}'` : ''}${
     play: async (context) => {
         const datePicker = within(context.canvasElement).getByTestId<DatePicker>('test-date-picker');
         datePicker.value = context.args.value;
-        
+
         await userEvent.click(datePicker);
 
         const calendar = (await querySelectorAsync(datePicker.shadowRoot as ShadowRoot, '#calendar')) as Calendar;
         await expect(calendar).toBeTruthy();
-      
+
         await waitFor(() => expect(calendar).toHaveAttribute('max-date', context.args.maxDate), {
             timeout: 3000
         });

--- a/src/date-picker/DatePicker.ts
+++ b/src/date-picker/DatePicker.ts
@@ -22,6 +22,8 @@ import '../icons/ChevronRight.icon.js';
  * <omni-date-picker
  *  label="Enter a value"
  *  value="2023-03-01"
+ *  min-date="2023-02-01"
+ *  max-date="2023-04-01"
  *  hint="Required"
  *  error="Select a valid date"
  *  locale="en-US"
@@ -90,6 +92,18 @@ export class DatePicker extends OmniFormElement {
      * @attr
      */
     @property({ type: String, reflect: true }) locale: string = this.defaultLocale;
+
+    /**
+     * The minimum date inclusively allowed to be selected.
+     * @attr [min-date]
+     */
+    @property({ type: String, attribute: 'min-date', reflect: true }) minDate?: string;
+
+    /**
+     * The maximum date inclusively allowed to be selected.
+     * @attr [max-date]
+     */
+    @property({ type: String, attribute: 'max-date', reflect: true }) maxDate?: string;
 
     // Internal state properties for date picker and
     @state() private date: DateTime =
@@ -420,7 +434,9 @@ export class DatePicker extends OmniFormElement {
                 <omni-calendar 
                   id="calendar" 
                   locale=${this.locale} 
-                  .value=${this.value as string} 
+                  .value=${this.value as string}
+                  .minDate=${this.minDate}
+                  .maxDate=${this.maxDate} 
                   @change=${(e: Event) => this._dateSelected(e)}>
                 </omni-calendar>
             </div>`;

--- a/src/utils/Directives.ts
+++ b/src/utils/Directives.ts
@@ -6,6 +6,6 @@ import { nothing } from 'lit';
  * @param value
  * @returns value or nothing
  */
-export function ifNotEmpty(value: string): string | any {
+export function ifNotEmpty(value?: string | null): string | any {
     return null !== value && value ? value : nothing;
 }


### PR DESCRIPTION
### Description:

closes #115 

* Added max-date to Calender
* Added min-date to DatePicker
* Added max-date to DatePicker
* Updated parameter types for `ifNotEmpty` directive

### Screenshots (if appropriate):

![image](https://github.com/capitec/omni-components/assets/16349308/4cf8aa31-e2ea-45f6-9035-44835ad9d286)
![image](https://github.com/capitec/omni-components/assets/16349308/6f68ee71-5ed5-4a2c-b16d-3793a2609223)


### All Submissions:

* [X] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [X] I have added an explanation of what my changes do and why I would like to include them.
* [X] I have written new tests for my core changes, as applicable.
* [X] I have successfully ran tests with my changes locally.
* [X] I have added/updated docs, as applicable.
