### PR TITLE
Update Pin Field to guard against setting non numeric values

### DIFF
--- a/.tooling/tests/dynamic.spec.js
+++ b/.tooling/tests/dynamic.spec.js
@@ -33,6 +33,12 @@ Object.keys(window).forEach((key) => {
     }
 });
 
+export function splitPascalCase(word) {
+	var wordRe = /($[a-z])|[A-Z][^A-Z]+/g;
+	return word.match(wordRe).join(' ');
+}
+
+
 /**
  * Test whether file is available and not locked 
  * @param {*} filePath 
@@ -168,9 +174,10 @@ const dynamicTests = async () => {
     const stories = globbySync('./dist/**/*.stories.js');
 
     for (let index = 0; index < stories.length; index++) {
-        const storyImport = path.join(process.cwd(), stories[index]);
-        const storyName = path.basename(stories[index].toLowerCase().replace('.stories.js', ''));
-        const storyPath = `http://localhost:6006/components/${storyName.replaceAll('-', '')}/`;
+        const storyImport = path.join(process.cwd(), stories[index]);       
+        const storyName = splitPascalCase(path.basename(stories[index].replace('.stories.js', '')));
+        const storyPath = `http://localhost:6006/components/${storyName.replaceAll(' ', '-').toLowerCase()}/`;
+
         let storyObj;
         try {
             storyObj = await import('file://' + storyImport);
@@ -190,7 +197,7 @@ const dynamicTests = async () => {
             const storyTest = storyTests[index2];
             const story = storyObj[storyTest];
 
-            test(`${storyName} - ${storyTest}`, async () => {
+            test(`${storyName} - ${storyTest.replaceAll('_',' ')}`, async () => {
                 await page.goto(storyPath);
 
                 if (!story || !story.play) {

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -89,10 +89,6 @@ export class PinField extends OmniFormElement {
         this.addEventListener('keyup', this._blurOnEnter.bind(this), {
             capture: true
         });
-        // Used to catch and format paste actions.
-        this.addEventListener('paste', this._onPaste.bind(this), {
-            capture: true
-        });
     }
 
     //Added for non webkit supporting browsers
@@ -155,22 +151,6 @@ export class PinField extends OmniFormElement {
             }
         }
         this.value = input?.value;
-    }
-
-    // When a value is pasted in the input.
-    _onPaste(e: ClipboardEvent) {
-        const input = this._inputElement as HTMLInputElement;
-        const clipboardData = e.clipboardData;
-        let pastedData = clipboardData?.getData('Text');
-
-        if (pastedData && new RegExp('^[0-9]+$').test(pastedData) === false) {
-            if (this.maxLength && pastedData.length > this.maxLength) {
-                pastedData = pastedData.slice(0, this.maxLength);
-            }
-            input.value = pastedData;
-        } else {
-            return;
-        }
     }
 
     _iconClicked(e: MouseEvent) {

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -113,11 +113,10 @@ export class PinField extends OmniFormElement {
     override async attributeChangedCallback(name: string, _old: string | null, value: string | null): Promise<void> {
         super.attributeChangedCallback(name, _old, value);
         if (name === 'value') {
-            //Check if the value provided is valid and numeric else set value to be empty string.
             if (value !== null && value !== undefined && new RegExp('^[0-9]+$').test(value as string) === false) {
-                value = '';
+                this.value = _old as string;
             } else if (this.maxLength && (value as string).length > this.maxLength) {
-                value = value?.slice(0, this.maxLength) as string;
+                this.value = value?.slice(0, this.maxLength) as string;
             }
         }
     }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -113,7 +113,7 @@ export class PinField extends OmniFormElement {
     override async attributeChangedCallback(name: string, _old: string | null, value: string | null): Promise<void> {
         super.attributeChangedCallback(name, _old, value);
         if (name === 'value') {
-            if (value !== null && value !== undefined && new RegExp('^[0-9]+$').test(value as string) === false) {
+            if (value !== null && value !== undefined && value !== '' && new RegExp('^[0-9]+$').test(value as string) === false) {
                 this.value = _old as string;
             } else if (this.maxLength && (value as string).length > this.maxLength) {
                 this.value = value?.slice(0, this.maxLength) as string;

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -105,7 +105,7 @@ export class PinField extends OmniFormElement {
         //Check if the value provided is valid and numeric else set value to be empty string.
         if (this.value !== null && this.value !== undefined && new RegExp('^[0-9]+$').test(this.value as string) === false) {
             this.value = '';
-        }else if(this.maxLength && (this.value as string).length > this.maxLength) {
+        } else if (this.maxLength && (this.value as string).length > this.maxLength) {
             this.value = String(this.value).slice(0, this.maxLength);
         }
     }
@@ -114,10 +114,10 @@ export class PinField extends OmniFormElement {
         super.attributeChangedCallback(name, _old, value);
         if (name === 'value') {
             //Check if the value provided is valid and numeric else set value to be empty string.
-            if (value !== null &&value !== undefined && new RegExp('^[0-9]+$').test(value as string) === false) {
+            if (value !== null && value !== undefined && new RegExp('^[0-9]+$').test(value as string) === false) {
                 value = '';
-            }else if(this.maxLength && (value as string).length > this.maxLength) {
-                value = value?.slice(0, this.maxLength) as string;  
+            } else if (this.maxLength && (value as string).length > this.maxLength) {
+                value = value?.slice(0, this.maxLength) as string;
             }
         }
     }
@@ -155,18 +155,18 @@ export class PinField extends OmniFormElement {
         this.value = input?.value;
     }
 
-     // When a value is pasted in the input.
-     _onPaste(e: ClipboardEvent) {
-         const input = this._inputElement as HTMLInputElement;
-         const clipboardData = e.clipboardData;
-         let pastedData = clipboardData?.getData('Text');
+    // When a value is pasted in the input.
+    _onPaste(e: ClipboardEvent) {
+        const input = this._inputElement as HTMLInputElement;
+        const clipboardData = e.clipboardData;
+        let pastedData = clipboardData?.getData('Text');
 
-        if (pastedData && (new RegExp('^[0-9]+$').test(pastedData) === false)){
-            if(this.maxLength && pastedData.length > this.maxLength){
-                pastedData = pastedData.slice(0, this.maxLength);    
+        if (pastedData && new RegExp('^[0-9]+$').test(pastedData) === false) {
+            if (this.maxLength && pastedData.length > this.maxLength) {
+                pastedData = pastedData.slice(0, this.maxLength);
             }
             input.value = pastedData;
-        }else {
+        } else {
             return;
         }
     }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -136,7 +136,7 @@ export class PinField extends OmniFormElement {
 
     _keyDown(e: KeyboardEvent) {
         // Stop alpha keys unless its a ctrl key combination ie: ctrl+c and specific characters
-        if ((!e.ctrlKey && e.key >= 'a' && e.key <= 'z') || e.key === '-' || e.key === '=' || e.key === '+' || e.key === '.') {
+        if (e.key === 'e' || e.key === '-' || e.key === '=' || e.key === '+' || e.key === '.') {
             e.preventDefault();
             return;
         }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -105,7 +105,7 @@ export class PinField extends OmniFormElement {
         //Check if the value provided is valid and numeric else set value to be empty string.
         if (this.value !== null && this.value !== undefined && new RegExp('^[0-9]+$').test(this.value as string) === false) {
             this.value = '';
-        } else if (this.maxLength && (this.value as string).length > this.maxLength) {
+        } else if (this.maxLength && this.value !== null && this.value !== undefined && (this.value as string).length > this.maxLength) {
             this.value = String(this.value).slice(0, this.maxLength);
         }
     }
@@ -137,7 +137,7 @@ export class PinField extends OmniFormElement {
 
     _keyDown(e: KeyboardEvent) {
         // Stop alpha keys
-        if (e.key >= 'a' && e.key <= 'z') {
+        if (!e.ctrlKey && (e.key >= 'a' && e.key <= 'z')) {
             e.preventDefault();
             return;
         }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -141,10 +141,10 @@ export class PinField extends OmniFormElement {
                     input.value = String(input?.value).slice(0, this.maxLength);
                 }
             }
-            // Required to not apply valid numeric symbols and the letter e to the input value
-            this.value = input?.value;
-            input!.value = this.value as string;
         }
+        // Required to not apply valid numeric symbols and the letter e to the input value
+        this.value = input?.value;
+        input!.value = this.value as string;
     }
 
     _iconClicked(e: MouseEvent) {

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -102,18 +102,21 @@ export class PinField extends OmniFormElement {
         if (!this.isWebkit) {
             this.type = 'password';
         }
-        //Check if the value provided is valid and numeric else set value to be empty string.
-        if (this.value !== null && this.value !== undefined && new RegExp('^[0-9]+$').test(this.value as string) === false) {
-            this.value = '';
-        } else if (this.maxLength && this.value !== null && this.value !== undefined && (this.value as string).length > this.maxLength) {
-            this.value = String(this.value).slice(0, this.maxLength);
+
+        if (this.value !== null && this.value !== undefined && this.value !== '') {
+            //Check if the value provided is valid and numeric else set value to be empty string.
+            if (new RegExp('^[0-9]+$').test(this.value as string) === false) {
+                this.value = '';
+            } else if (this.maxLength && (this.value as string).length > this.maxLength) {
+                this.value = String(this.value).slice(0, this.maxLength);
+            }
         }
     }
 
     override async attributeChangedCallback(name: string, _old: string | null, value: string | null): Promise<void> {
         super.attributeChangedCallback(name, _old, value);
-        if (name === 'value') {
-            if (value !== null && value !== undefined && value !== '' && new RegExp('^[0-9]+$').test(value as string) === false) {
+        if (name === 'value' && value !== null && value !== undefined && value !== '') {
+            if (new RegExp('^[0-9]+$').test(value as string) === false) {
                 this.value = _old as string;
             } else if (this.maxLength && (value as string).length > this.maxLength) {
                 this.value = value?.slice(0, this.maxLength) as string;
@@ -137,7 +140,7 @@ export class PinField extends OmniFormElement {
 
     _keyDown(e: KeyboardEvent) {
         // Stop alpha keys
-        if (!e.ctrlKey && (e.key >= 'a' && e.key <= 'z')) {
+        if (!e.ctrlKey && e.key >= 'a' && e.key <= 'z') {
             e.preventDefault();
             return;
         }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -89,6 +89,10 @@ export class PinField extends OmniFormElement {
         this.addEventListener('keyup', this._blurOnEnter.bind(this), {
             capture: true
         });
+        // Used to catch and format paste actions.
+        this.addEventListener('paste', this._onPaste.bind(this), {
+            capture: true
+        });
     }
 
     //Added for non webkit supporting browsers
@@ -98,13 +102,22 @@ export class PinField extends OmniFormElement {
         if (!this.isWebkit) {
             this.type = 'password';
         }
+        //Check if the value provided is valid and numeric else set value to be empty string.
+        if (this.value !== null && this.value !== undefined && new RegExp('^[0-9]+$').test(this.value as string) === false) {
+            this.value = '';
+        }else if(this.maxLength && (this.value as string).length > this.maxLength) {
+            this.value = String(this.value).slice(0, this.maxLength);
+        }
     }
 
     override async attributeChangedCallback(name: string, _old: string | null, value: string | null): Promise<void> {
         super.attributeChangedCallback(name, _old, value);
         if (name === 'value') {
-            if (new RegExp('^[0-9]+$').test(value as string) === false) {
-                return;
+            //Check if the value provided is valid and numeric else set value to be empty string.
+            if (value !== null &&value !== undefined && new RegExp('^[0-9]+$').test(value as string) === false) {
+                value = '';
+            }else if(this.maxLength && (value as string).length > this.maxLength) {
+                value = value?.slice(0, this.maxLength) as string;  
             }
         }
     }
@@ -140,6 +153,22 @@ export class PinField extends OmniFormElement {
             }
         }
         this.value = input?.value;
+    }
+
+     // When a value is pasted in the input.
+     _onPaste(e: ClipboardEvent) {
+         const input = this._inputElement as HTMLInputElement;
+         const clipboardData = e.clipboardData;
+         let pastedData = clipboardData?.getData('Text');
+
+        if (pastedData && (new RegExp('^[0-9]+$').test(pastedData) === false)){
+            if(this.maxLength && pastedData.length > this.maxLength){
+                pastedData = pastedData.slice(0, this.maxLength);    
+            }
+            input.value = pastedData;
+        }else {
+            return;
+        }
     }
 
     _iconClicked(e: MouseEvent) {

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -104,9 +104,9 @@ export class PinField extends OmniFormElement {
         }
 
         if (this.value !== null && this.value !== undefined && this.value !== '') {
-            //Check if the value provided is valid and numeric else set value to be empty string.
+            //Check if the value provided is valid and numeric else remove the value attribute.
             if (new RegExp('^[0-9]+$').test(this.value as string) === false) {
-                this.value = '';
+                this.removeAttribute('value');
             } else if (this.maxLength && (this.value as string).length > this.maxLength) {
                 this.value = String(this.value).slice(0, this.maxLength);
             }
@@ -117,7 +117,7 @@ export class PinField extends OmniFormElement {
         super.attributeChangedCallback(name, _old, value);
         if (name === 'value' && value !== null && value !== undefined && value !== '') {
             if (new RegExp('^[0-9]+$').test(value as string) === false) {
-                this.value = _old as string;
+                this.removeAttribute('value');
             } else if (this.maxLength && (value as string).length > this.maxLength) {
                 this.value = value?.slice(0, this.maxLength) as string;
             }
@@ -139,8 +139,8 @@ export class PinField extends OmniFormElement {
     }
 
     _keyDown(e: KeyboardEvent) {
-        // Stop alpha keys
-        if (!e.ctrlKey && e.key >= 'a' && e.key <= 'z') {
+        // Stop alpha keys and specific characters
+        if ((!e.ctrlKey && e.key >= 'a' && e.key <= 'z') || e.key === '-' || e.key === '=' || e.key === '+' || e.key === '.') {
             e.preventDefault();
             return;
         }

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -83,9 +83,6 @@ export class PinField extends OmniFormElement {
         this.addEventListener('input', this._keyInput.bind(this), {
             capture: true
         });
-        this.addEventListener('keydown', this._keyDown.bind(this), {
-            capture: true
-        });
         this.addEventListener('keyup', this._blurOnEnter.bind(this), {
             capture: true
         });
@@ -134,14 +131,6 @@ export class PinField extends OmniFormElement {
         }
     }
 
-    _keyDown(e: KeyboardEvent) {
-        // Stop alpha keys unless its a ctrl key combination ie: ctrl+c and specific characters
-        if (e.key === 'e' || e.key === '-' || e.key === '=' || e.key === '+' || e.key === '.') {
-            e.preventDefault();
-            return;
-        }
-    }
-
     _keyInput() {
         const input = this._inputElement;
         if (input?.value && this.maxLength && typeof this.maxLength === 'number') {
@@ -150,7 +139,9 @@ export class PinField extends OmniFormElement {
                 input.value = String(input?.value).slice(0, this.maxLength);
             }
         }
+        // Required to not apply valid numeric symbols and the letter e to the input value
         this.value = input?.value;
+        input!.value = this.value as string;
     }
 
     _iconClicked(e: MouseEvent) {

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -139,7 +139,7 @@ export class PinField extends OmniFormElement {
     }
 
     _keyDown(e: KeyboardEvent) {
-        // Stop alpha keys and specific characters
+        // Stop alpha keys unless its a ctrl key combination ie: ctrl+c and specific characters
         if ((!e.ctrlKey && e.key >= 'a' && e.key <= 'z') || e.key === '-' || e.key === '=' || e.key === '+' || e.key === '.') {
             e.preventDefault();
             return;

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -133,15 +133,18 @@ export class PinField extends OmniFormElement {
 
     _keyInput() {
         const input = this._inputElement;
-        if (input?.value && this.maxLength && typeof this.maxLength === 'number') {
-            if (String(input?.value).length > this.maxLength) {
-                // Restrict the input characters to the length of specified in the args.
-                input.value = String(input?.value).slice(0, this.maxLength);
+        // Check if the value of the input field is valid based on the regex.
+        if (new RegExp('^[0-9]+$').test(input?.value as string) === true) {
+            if (input?.value && this.maxLength && typeof this.maxLength === 'number') {
+                if (String(input?.value).length > this.maxLength) {
+                    // Restrict the input characters to the length of specified in the args.
+                    input.value = String(input?.value).slice(0, this.maxLength);
+                }
             }
+            // Required to not apply valid numeric symbols and the letter e to the input value
+            this.value = input?.value;
+            input!.value = this.value as string;
         }
-        // Required to not apply valid numeric symbols and the letter e to the input value
-        this.value = input?.value;
-        input!.value = this.value as string;
     }
 
     _iconClicked(e: MouseEvent) {


### PR DESCRIPTION
## Description:

closes #125 

- Enhance guard of the Pin Field to stop the setting of non-numeric values.
- Allow the use of keyboard shortcuts for the Pin Field.
- Updates to resolve test failures for stories.

## Test results

![image](https://github.com/capitec/omni-components/assets/22874454/147026df-d335-4bec-bcd6-7048f2446a9d)

## Key input test scenarios


### Alpha keys
--------------------------------------------------------------------------------------------------------------------------------------------

**Before**

![Pin field setting non numeric value](https://github.com/capitec/omni-components/assets/22874454/1d27fb37-658c-40cc-888f-dc73534b8bdb)

**After**

![Pin field setting non numeric value after](https://github.com/capitec/omni-components/assets/22874454/4504a54f-39a0-4cbb-8c3f-d6e804d63c8a)


### Special characters
--------------------------------------------------------------------------------------------------------------------------------------------
**before (Note period character ".", "+" ,"-" used)**

![Pin field setting special characters](https://github.com/capitec/omni-components/assets/22874454/4b303fd5-6fd1-485d-aab7-66b0d67b9b8a)

**after**

![Pin field setting special characters after](https://github.com/capitec/omni-components/assets/22874454/a05a5f30-6f37-402f-9923-dc8603d4d4f5)


### Keyboard shortcut scenarios
-----------------------------------------------------------------

**ctrl+c**

before 

![Pin field copy shortcut before](https://github.com/capitec/omni-components/assets/22874454/41f7c9a8-9e10-46b1-a8a2-59877131341a)

after

![Pin field copy shortcut after](https://github.com/capitec/omni-components/assets/22874454/bc63232a-39ff-4ff6-a8e6-b59b79aea0d2)

--------------------------------------------------------------------------------------------------------------------------------------------

**ctrl+x**

before 

![Pin field cut shortcut](https://github.com/capitec/omni-components/assets/22874454/ddc778f6-96ef-4324-9031-6febaa8e43fe)

after

![Pin field cut shortcut after](https://github.com/capitec/omni-components/assets/22874454/1edbd244-6f80-43da-9746-d931d71c7efe)

--------------------------------------------------------------------------------------------------------------------------------------------

**ctrl+v**

before

![Pin field paste shortcut](https://github.com/capitec/omni-components/assets/22874454/5bb917a7-ae64-4ab7-8075-2d1bd2ddc36c)

after

![Pin field paste shortcut after](https://github.com/capitec/omni-components/assets/22874454/f2883af6-040d-439c-a577-072a4c037537)


### All Submissions:
-----------------------------------------------------------------

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
