### PR TITLE
Fix min and max date properties mobile implementation

### DIFF
--- a/src/date-picker/DatePicker.ts
+++ b/src/date-picker/DatePicker.ts
@@ -422,6 +422,8 @@ export class DatePicker extends OmniFormElement {
                     id="calendar" 
                     locale=${this.locale} 
                     .value=${this.value as string} 
+                    .minDate=${this.minDate}
+                    .maxDate=${this.maxDate} 
                     @change=${(e: Event) => this._dateSelected(e)}>
                 </omni-calendar>
             </dialog>`;


### PR DESCRIPTION
### Description:

closes #150 

The min and max date properties was not correctly bound on the Date picker component mobile template. This was picked up during the mobile testing POC.

The fix was tested locally by using browser dev tools to simulate mobile testing.

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.

### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
