### PR TITLE
Added Toast static functions for showing and configuring

### DIFF
--- a/src/toast/Toast.stories.ts
+++ b/src/toast/Toast.stories.ts
@@ -106,6 +106,42 @@ document.querySelector('omni-button').addEventListener('click', () => {
             }
         },
         {
+            framework: 'Vue',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="showToast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+window.vueData = {
+    showToast: () => {
+        Toast.show({
+            type: 'success',
+            header: 'Success!',
+            detail: 'It was successful.',
+            closeable: true,
+            duration: 3000
+        });
+    }
+};`
+            }
+        },
+        {
+            framework: 'Lit',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="\${showToast}"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+const showToast = () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+}`
+            }
+        },
+        {
             framework: 'React',
             load: (args) => `import { OmniButton } from "@capitec/omni-components-react/button";
 import { Toast } from '@capitec/omni-components-react/toast';
@@ -173,6 +209,50 @@ document.querySelector('omni-button').addEventListener('click', () => {
         duration: 3000
     });
 });`
+            }
+        },
+        {
+            framework: 'Vue',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="showToast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+Toast.configure({
+    position: 'top'
+});
+
+window.vueData = {
+    showToast: () => {
+        Toast.show({
+            type: 'success',
+            header: 'Success!',
+            detail: 'It was successful.',
+            closeable: true,
+            duration: 3000
+        });
+    }
+};`
+            }
+        },
+        {
+            framework: 'Lit',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="\${showToast}"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+Toast.configure({
+    position: 'top'
+});
+
+const showToast = () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+}`
             }
         },
         {
@@ -245,6 +325,44 @@ document.querySelector('omni-button').addEventListener('click', () => {
         duration: 3000
     });
 });`
+            }
+        },
+        {
+            framework: 'Vue',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="showToast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+window.vueData = {
+    showToast: () => {
+        Toast.show({
+            stack: true,
+            type: 'success',
+            header: 'Success!',
+            detail: 'It was successful.',
+            closeable: true,
+            duration: 3000
+        });
+    }
+};`
+            }
+        },
+        {
+            framework: 'Lit',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast" @click="\${showToast}"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+const showToast = () => {
+    Toast.show({
+        stack: true,
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+}`
             }
         },
         {

--- a/src/toast/Toast.stories.ts
+++ b/src/toast/Toast.stories.ts
@@ -74,14 +74,15 @@ export const Showing_Toasts: ComponentStoryFormat<Args> = {
             @click="${() => {
                 Toast.configure({
                     position: 'bottom',
-                    reverse: false
+                    reverse: false,
+                    stack: true,
+                    closeable: undefined,
+                    duration: undefined
                 });
                 Toast.show({
                     type: 'success',
                     header: 'Success!',
-                    detail: 'It was successful.',
-                    closeable: true,
-                    duration: 3000
+                    detail: 'It was successful.'
                 });
             }}"
             >
@@ -98,9 +99,7 @@ document.querySelector('omni-button').addEventListener('click', () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 });`
             }
@@ -116,9 +115,7 @@ window.vueData = {
         Toast.show({
             type: 'success',
             header: 'Success!',
-            detail: 'It was successful.',
-            closeable: true,
-            duration: 3000
+            detail: 'It was successful.'
         });
     }
 };`
@@ -134,9 +131,7 @@ const showToast = () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 }`
             }
@@ -150,9 +145,7 @@ const showToast = () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 };
 
@@ -175,15 +168,17 @@ export const Configure_Toast: ComponentStoryFormat<Args> = {
             label="Show Toast"
             @click="${() => {
                 Toast.configure({
-                    position: 'top',
-                    reverse: false
+                    position: 'left',
+                    reverse: true,
+                    stack: true,
+                    closeable: undefined,
+                    // Defaults to 3000ms when not specified. If set to 0 will be infinite (or until close clicked)
+                    duration: undefined
                 });
                 Toast.show({
                     type: 'success',
                     header: 'Success!',
                     detail: 'It was successful.',
-                    closeable: true,
-                    duration: 3000
                 });
             }}"
             >
@@ -197,16 +192,19 @@ export const Configure_Toast: ComponentStoryFormat<Args> = {
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
 
 Toast.configure({
-    position: 'top'
+    position: 'left',
+    reverse: true,
+    stack: true,
+    closeable: undefined,
+    // Defaults to 3000ms when not specified. If set to 0 will be infinite (or until close clicked)
+    duration: undefined
 });
 
 document.querySelector('omni-button').addEventListener('click', () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 });`
             }
@@ -218,7 +216,12 @@ document.querySelector('omni-button').addEventListener('click', () => {
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
 
 Toast.configure({
-    position: 'top'
+    position: 'left',
+    reverse: true,
+    stack: true,
+    closeable: undefined,
+    // Defaults to 3000ms when not specified. If set to 0 will be infinite (or until close clicked)
+    duration: undefined
 });
 
 window.vueData = {
@@ -226,9 +229,7 @@ window.vueData = {
         Toast.show({
             type: 'success',
             header: 'Success!',
-            detail: 'It was successful.',
-            closeable: true,
-            duration: 3000
+            detail: 'It was successful.'
         });
     }
 };`
@@ -241,16 +242,19 @@ window.vueData = {
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
 
 Toast.configure({
-    position: 'top'
+    position: 'left',
+    reverse: true,
+    stack: true,
+    closeable: undefined,
+    // Defaults to 3000ms when not specified. If set to 0 will be infinite (or until close clicked)
+    duration: undefined
 });
 
 const showToast = () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 }`
             }
@@ -261,16 +265,19 @@ const showToast = () => {
 import { Toast } from '@capitec/omni-components-react/toast';
 
 Toast.configure({
-    position: 'top'
+    position: 'left',
+    reverse: true,
+    stack: true,
+    closeable: undefined,
+    // Defaults to 3000ms when not specified. If set to 0 will be infinite (or until close clicked)
+    duration: undefined
 });
 
 const showToast = () => {
     Toast.show({
         type: 'success',
         header: 'Success!',
-        detail: 'It was successful.',
-        closeable: true,
-        duration: 3000
+        detail: 'It was successful.'
     });
 };
 
@@ -281,28 +288,31 @@ const App = () => <OmniButton label="Show Toast" onclick={showToast}/>;`
     args: {}
 };
 
-export const Stacking_Toasts: ComponentStoryFormat<Args> = {
+export const Replacing_Toasts: ComponentStoryFormat<Args> = {
     description: () => html`
     <div>
-        Toasts can be stacked instead of replaced when shown programmatically via the static <code class="language-js">Toast.show()</code> function by setting <code>stack</code> to <code class="language-js">true</code>. 
+        Toasts can be replaced instead of stacked when shown programmatically via the static <code class="language-js">Toast.show()</code> function by using the static <code class="language-js">Toast.configure()</code> function to set <code>stack</code> to <code class="language-js">false</code>. 
     <div>
     `,
     render: (args: Args) => html`
         <omni-button
             data-testid="test-toast-show"
-            label="Stack Toast"
+            label="Show Toast"
             @click="${() => {
                 Toast.configure({
                     position: 'bottom',
-                    reverse: false
+                    reverse: false,
+                    stack: false,
+                    closeable: undefined,
+                    duration: undefined
                 });
                 Toast.show({
-                    stack: true,
                     type: 'success',
                     header: 'Success!',
                     detail: 'It was successful.',
                     closeable: true,
-                    duration: 3000
+                    // Defaults to 3000ms (or configured duration via Toast.configure function) when not specified. If set to 0 will be infinite (or until close clicked)
+                    duration: 0
                 });
             }}"
             >
@@ -312,17 +322,19 @@ export const Stacking_Toasts: ComponentStoryFormat<Args> = {
         {
             framework: 'HTML',
             sourceParts: {
-                htmlFragment: raw`<omni-button label="Stack Toast"></omni-button>`,
+                htmlFragment: raw`<omni-button label="Show Toast"></omni-button>`,
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+Toast.configure({ stack: false });
 
 document.querySelector('omni-button').addEventListener('click', () => {
     Toast.show({
-        stack: true,
         type: 'success',
         header: 'Success!',
         detail: 'It was successful.',
         closeable: true,
-        duration: 3000
+        // Defaults to 3000ms (or configured duration via Toast.configure function) when not specified. If set to 0 will be infinite (or until close clicked)
+        duration: 0
     });
 });`
             }
@@ -333,6 +345,8 @@ document.querySelector('omni-button').addEventListener('click', () => {
                 htmlFragment: raw`<omni-button label="Show Toast" @click="showToast"></omni-button>`,
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
 
+Toast.configure({ stack: false });
+
 window.vueData = {
     showToast: () => {
         Toast.show({
@@ -341,7 +355,8 @@ window.vueData = {
             header: 'Success!',
             detail: 'It was successful.',
             closeable: true,
-            duration: 3000
+            // Defaults to 3000ms (or configured duration via Toast.configure function) when not specified. If set to 0 will be infinite (or until close clicked)
+            duration: 0
         });
     }
 };`
@@ -353,14 +368,16 @@ window.vueData = {
                 htmlFragment: raw`<omni-button label="Show Toast" @click="\${showToast}"></omni-button>`,
                 jsFragment: `import { Toast } from '@capitec/omni-components/toast';
 
+Toast.configure({ stack: false });
+
 const showToast = () => {
     Toast.show({
-        stack: true,
         type: 'success',
         header: 'Success!',
         detail: 'It was successful.',
         closeable: true,
-        duration: 3000
+        // Defaults to 3000ms (or configured duration via Toast.configure function) when not specified. If set to 0 will be infinite (or until close clicked)
+        duration: 0
     });
 }`
             }
@@ -370,21 +387,23 @@ const showToast = () => {
             load: (args) => `import { OmniButton } from "@capitec/omni-components-react/button";
 import { Toast } from '@capitec/omni-components-react/toast';
 
+Toast.configure({ stack: false });
+
 const showToast = () => {
     Toast.show({
-        stack: true,
         type: 'success',
         header: 'Success!',
         detail: 'It was successful.',
         closeable: true,
-        duration: 3000
+        // Defaults to 3000ms (or configured duration via Toast.configure function) when not specified. If set to 0 will be infinite (or until close clicked)
+        duration: 0
     });
 };
 
-const App = () => <OmniButton label="Stack Toast" onclick={showToast}/>;`
+const App = () => <OmniButton label="Show Toast" onclick={showToast}/>;`
         }
     ],
-    name: 'Stacking Toast Programmatically',
+    name: 'Replacing Toast Programmatically',
     args: {}
 };
 

--- a/src/toast/Toast.stories.ts
+++ b/src/toast/Toast.stories.ts
@@ -178,7 +178,7 @@ export const Configure_Toast: ComponentStoryFormat<Args> = {
                 Toast.show({
                     type: 'success',
                     header: 'Success!',
-                    detail: 'It was successful.',
+                    detail: 'It was successful.'
                 });
             }}"
             >

--- a/src/toast/Toast.stories.ts
+++ b/src/toast/Toast.stories.ts
@@ -9,6 +9,7 @@ import { assignToSlot, ComponentStoryFormat, CSFIdentifier, getSourceFromLit, ra
 import { Toast } from './Toast.js';
 
 import './Toast.js';
+import '../button/Button.js';
 
 export default {
     title: 'UI Components/Toast',
@@ -58,6 +59,215 @@ export const Interactive: ComponentStoryFormat<Args> = {
         const toast = within(context.canvasElement).getByTestId<Toast>('test-toast');
         toast.focus();
     }
+};
+
+export const Showing_Toasts: ComponentStoryFormat<Args> = {
+    description: () => html`
+    <div>
+        Toasts can be shown programmatically using the static <code class="language-js">Toast.show()</code> function. 
+    <div>
+    `,
+    render: (args: Args) => html`
+        <omni-button
+            data-testid="test-toast-show"
+            label="Show Toast"
+            @click="${() => {
+                Toast.configure({
+                    position: 'bottom',
+                    reverse: false
+                });
+                Toast.show({
+                    type: 'success',
+                    header: 'Success!',
+                    detail: 'It was successful.',
+                    closeable: true,
+                    duration: 3000
+                });
+            }}"
+            >
+        </omni-button>
+    `,
+    frameworkSources: [
+        {
+            framework: 'HTML',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+document.querySelector('omni-button').addEventListener('click', () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+});`
+            }
+        },
+        {
+            framework: 'React',
+            load: (args) => `import { OmniButton } from "@capitec/omni-components-react/button";
+import { Toast } from '@capitec/omni-components-react/toast';
+
+const showToast = () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+};
+
+const App = () => <OmniButton label="Show Toast" onclick={showToast}/>;`
+        }
+    ],
+    name: 'Showing Toast Programmatically',
+    args: {}
+};
+
+export const Configure_Toast: ComponentStoryFormat<Args> = {
+    description: () => html`
+    <div>
+       Programmatically shown Toasts can be configured using the static <code class="language-js">Toast.configure()</code> function. 
+    <div>
+    `,
+    render: (args: Args) => html`
+        <omni-button
+            data-testid="test-toast-configure"
+            label="Show Toast"
+            @click="${() => {
+                Toast.configure({
+                    position: 'top',
+                    reverse: false
+                });
+                Toast.show({
+                    type: 'success',
+                    header: 'Success!',
+                    detail: 'It was successful.',
+                    closeable: true,
+                    duration: 3000
+                });
+            }}"
+            >
+        </omni-button>
+    `,
+    frameworkSources: [
+        {
+            framework: 'HTML',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Show Toast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+Toast.configure({
+    position: 'top'
+});
+
+document.querySelector('omni-button').addEventListener('click', () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+});`
+            }
+        },
+        {
+            framework: 'React',
+            load: (args) => `import { OmniButton } from "@capitec/omni-components-react/button";
+import { Toast } from '@capitec/omni-components-react/toast';
+
+Toast.configure({
+    position: 'top'
+});
+
+const showToast = () => {
+    Toast.show({
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+};
+
+const App = () => <OmniButton label="Show Toast" onclick={showToast}/>;`
+        }
+    ],
+    name: 'Configure Toast Programmatically',
+    args: {}
+};
+
+export const Stacking_Toasts: ComponentStoryFormat<Args> = {
+    description: () => html`
+    <div>
+        Toasts can be stacked instead of replaced when shown programmatically via the static <code class="language-js">Toast.show()</code> function by setting <code>stack</code> to <code class="language-js">true</code>. 
+    <div>
+    `,
+    render: (args: Args) => html`
+        <omni-button
+            data-testid="test-toast-show"
+            label="Stack Toast"
+            @click="${() => {
+                Toast.configure({
+                    position: 'bottom',
+                    reverse: false
+                });
+                Toast.show({
+                    stack: true,
+                    type: 'success',
+                    header: 'Success!',
+                    detail: 'It was successful.',
+                    closeable: true,
+                    duration: 3000
+                });
+            }}"
+            >
+        </omni-button>
+    `,
+    frameworkSources: [
+        {
+            framework: 'HTML',
+            sourceParts: {
+                htmlFragment: raw`<omni-button label="Stack Toast"></omni-button>`,
+                jsFragment: `import { Toast } from '@capitec/omni-components/toast';
+
+document.querySelector('omni-button').addEventListener('click', () => {
+    Toast.show({
+        stack: true,
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+});`
+            }
+        },
+        {
+            framework: 'React',
+            load: (args) => `import { OmniButton } from "@capitec/omni-components-react/button";
+import { Toast } from '@capitec/omni-components-react/toast';
+
+const showToast = () => {
+    Toast.show({
+        stack: true,
+        type: 'success',
+        header: 'Success!',
+        detail: 'It was successful.',
+        closeable: true,
+        duration: 3000
+    });
+};
+
+const App = () => <OmniButton label="Stack Toast" onclick={showToast}/>;`
+        }
+    ],
+    name: 'Stacking Toast Programmatically',
+    args: {}
 };
 
 export const Custom_Slotted_Content: ComponentStoryFormat<Args> = {

--- a/src/toast/Toast.ts
+++ b/src/toast/Toast.ts
@@ -1,6 +1,7 @@
 import { html, css, TemplateResult, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { OmniElement } from '../core/OmniElement.js';
+import { type ShowToastInit, ToastStack } from './ToastStack.js';
 
 import '../icons/Close.icon.js';
 
@@ -108,6 +109,65 @@ export class Toast extends OmniElement {
      * @attr
      */
     @property({ type: Boolean, reflect: true }) closeable?: boolean;
+
+    private static stack?: ToastStack;
+
+    /**
+     * Global singleton {@link ToastStack} used for showing a toast, either by adding to, or replacing.
+     * Use `Toast.show` function to add or replace toasts to this instance.
+     */
+    public static get current() {
+        if (!Toast.stack) {
+            Toast.stack = ToastStack.create({});
+        }
+        return Toast.stack as ToastStack;
+    }
+
+    /**
+     * Configure the global singleton {@link ToastStack} used for showing a toast, either by adding to, or replacing.
+     * Use `Toast.show` function to add or replace toasts to this instance.
+     * @returns The global singleton {@link ToastStack} instance. It can also be accessed via `Toast.current` static property.
+     */
+    public static configure(options: {
+        /**
+         * The position to stack toasts
+         */
+        position?: 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+        /**
+         * Reverse the order of toast with newest toasts showed on top of the stack. By default newest toasts are showed at the bottom of the stack.
+         */
+        reverse?: boolean;
+    }) {
+        const current = Toast.current;
+        if (options) {
+            if (options.position) {
+                current.position = options.position;
+            }
+            if (typeof options.reverse !== 'undefined') {
+                current.reverse = options.reverse;
+            }
+        }
+        return current;
+    }
+
+    /**
+     * Show a toast message.
+     * @returns The {@link Toast} instance that was created.
+     */
+    public static show(
+        options: {
+            /**
+             * When true, will append toast to the toast stack. Otherwise by default will replace any toast(s).
+             */
+            stack?: boolean;
+        } & ShowToastInit
+    ) {
+        const current = Toast.current;
+        if (!options.stack) {
+            current.innerHTML = '';
+        }
+        return current.showToast(options);
+    }
 
     private _raiseCloseClick(event: MouseEvent) {
         // Notify any subscribers that the close button was clicked.

--- a/src/toast/Toast.ts
+++ b/src/toast/Toast.ts
@@ -122,7 +122,7 @@ export class Toast extends OmniElement {
         closeable?: boolean;
 
         /**
-         * If provided will be the time in millisecond the toast is displayed before being automatically removed from the stack.
+         * If provided will be the time in milliseconds the toast is displayed before being automatically removed from the stack.
          * Defaults to 3000ms when not provided.
          * When set to 0 will amount to no timeout.
          */

--- a/src/toast/ToastStack.ts
+++ b/src/toast/ToastStack.ts
@@ -495,7 +495,7 @@ export type ShowToastInit = {
  */
 export type ShowToastOptions = {
     /**
-     * If provided will be the time in millisecond the toast is displayed before being automatically removed from the stack.
+     * If provided will be the time in milliseconds the toast is displayed before being automatically removed from the stack.
      */
     duration?: number;
 

--- a/src/toast/ToastStack.ts
+++ b/src/toast/ToastStack.ts
@@ -81,7 +81,8 @@ export class ToastStack extends OmniElement {
      * @param init Initialisation context for the element.
      * @returns The {@link ToastStack} instance that was created.
      */
-    public static create(init: ToastStackInit) {
+    public static create(init?: ToastStackInit) {
+        init = init ?? {};
         if (!init.parent) {
             // If no parent element is specified, the ToastStack will be appended directly on the document body.
             init.parent = document.createElement('div');
@@ -147,17 +148,31 @@ export class ToastStack extends OmniElement {
             toast.appendChild(renderElement);
         }
 
+        return this.showInstance(toast);
+    }
+
+    /**
+     * Push a toast instance onto the toast stack.
+     */
+    public showInstance(instance: Toast, options?: ShowToastOptions) {
+        if (options?.duration) {
+            instance.setAttribute(toastDurationAttribute, options.duration.toString());
+        }
+        if (typeof options?.closeable !== 'undefined') {
+            instance.closeable = options.closeable;
+        }
+
         const { matches: motionOK } = window.matchMedia(animationAllowedMedia);
 
         if (motionOK && document.timeline) {
             // Animate in the toast if the user allows motion.
-            this.slideIn(toast);
+            this.slideIn(instance);
         } else {
             // Add the toast to the stack without animation.
-            this.appendChild(toast);
+            this.appendChild(instance);
         }
 
-        return toast;
+        return instance;
     }
 
     private onSlotChange() {
@@ -473,6 +488,21 @@ export type ShowToastInit = {
      * Content to render as the close button when `closeable`.
      */
     close?: RenderFunction | RenderResult;
+};
+
+/**
+ * Context for `showToast` function to programmatically add an existing `<omni-toast>` instance to an existing `<omni-toast-stack>`.
+ */
+export type ShowToastOptions = {
+    /**
+     * If provided will be the time in millisecond the toast is displayed before being automatically removed from the stack.
+     */
+    duration?: number;
+
+    /**
+     * If true, will display a close button that fires a `close-click` event when clicked and removes the toast from the stack.
+     */
+    closeable?: boolean;
 };
 
 declare global {


### PR DESCRIPTION
### Description:

Cater for simple use case where toasts need to be programmatically shown without the need to track an instance of an `omni-toast-stack`

### Screenshots (if appropriate):

![image](https://github.com/capitec/omni-components/assets/16349308/3692cc42-d353-4fce-978f-7781da50efa1)


### All Submissions:

* [X] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [X] I have added an explanation of what my changes do and why I would like to include them.
* [X] I have written new tests for my core changes, as applicable.
* [X] I have successfully ran tests with my changes locally.
* [X] I have added/updated docs, as applicable.
