### PR TITLE
Set modal footer border radius

### DIFF
--- a/src/modal/Modal.ts
+++ b/src/modal/Modal.ts
@@ -77,6 +77,7 @@ import '../render-element/RenderElement.js';
  * @cssprop --omni-modal-no-header-body-border-top-radius - Top border radius for modal body when there is no header.
  * @cssprop --omni-modal-no-footer-body-border-bottom-radius - Bottom border radius for modal body when there is no footer.
  *
+ * @cssprop --omni-modal-footer-border-bottom-radius - Bottom border radius for modal footer.
  * @cssprop --omni-modal-footer-text-align - Text align for modal footer.
  * @cssprop --omni-modal-footer-padding - Padding for modal footer.
  * @cssprop --omni-modal-footer-font-color - Font color for modal footer.
@@ -306,6 +307,8 @@ export class Modal extends OmniElement {
                 }
 
                 .footer {
+                    border-bottom-left-radius: var(--omni-modal-footer-border-bottom-radius, 4px);
+                    border-bottom-right-radius: var(--omni-modal-footer-border-bottom-radius, 4px);
                     align-self: stretch;
                     text-align: var(--omni-modal-footer-text-align, right);
                     padding: var(--omni-modal-footer-padding, 12px 12px 12px 0px);

--- a/src/modal/README.md
+++ b/src/modal/README.md
@@ -71,6 +71,7 @@ Control to display modal content with optional header and footer content.
 | `--omni-modal-dialog-right`                      | Right position for wrapping `HTMLDialogElement`. |
 | `--omni-modal-dialog-top`                        | Top position for wrapping `HTMLDialogElement`.   |
 | `--omni-modal-footer-background`                 | Background for modal footer.                     |
+| `--omni-modal-footer-border-bottom-radius`       | Bottom border radius for modal footer.           |
 | `--omni-modal-footer-font-color`                 | Font color for modal footer.                     |
 | `--omni-modal-footer-font-family`                | Font family for modal footer.                    |
 | `--omni-modal-footer-font-size`                  | Font size for modal footer.                      |


### PR DESCRIPTION
### Description:

Added configuration for the footer border radius as there is currently no way to configure this.

### Screenshots (if appropriate):

Notice the border radius at the bottom of the modal:

Before:
![image](https://github.com/capitec/omni-components/assets/142491549/e02f0431-7cd3-4692-8895-f18f37966541)

After:
![image](https://github.com/capitec/omni-components/assets/142491549/39502ea1-4030-4edd-8b25-64693084960f)


### All Submissions:

* [ ] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [ ] I have added an explanation of what my changes do and why I would like to include them.
* [ ] I have written new tests for my core changes, as applicable.
* [ ] I have successfully ran tests with my changes locally.
* [ ] I have added/updated docs, as applicable.
