### PR TITLE
Bug -  Resolve Pin and Password field rendering issue

### DIFF
--- a/src/password-field/PasswordField.ts
+++ b/src/password-field/PasswordField.ts
@@ -1,4 +1,4 @@
-import { css, html } from 'lit';
+import { PropertyValueMap, css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { ifDefined, OmniFormElement } from '../core/OmniFormElement.js';
@@ -74,7 +74,6 @@ export class PasswordField extends OmniFormElement {
     private _inputElement?: HTMLInputElement;
     @query('.container')
     private container?: HTMLDivElement;
-    private _value? = '';
 
     override connectedCallback() {
         super.connectedCallback();
@@ -90,26 +89,17 @@ export class PasswordField extends OmniFormElement {
         this._setInputValue();
     }
 
-    constructor() {
-        super();
-        this._value = this.value ?? '';
-        Object.defineProperty(this, 'value', {
-            get: () => {
-                return this._value;
-            },
-            set: (v) => {
-                this._value = v ?? '';
-                this._setInputValue();
-                if (this._value) {
-                    this.container?.classList?.add('float-label');
-                    this.container?.classList?.remove('no-float-label');
-                } else {
-                    this.container?.classList?.remove('float-label');
-                    this.container?.classList?.add('no-float-label');
-                }
-                this.requestUpdate();
+    protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
+        if (_changedProperties.has('value')) {
+            if (this.value) {
+                this.container?.classList?.add('float-label');
+                this.container?.classList?.remove('no-float-label');
+            } else {
+                this.container?.classList?.remove('float-label');
+                this.container?.classList?.add('no-float-label');
             }
-        });
+            this._setInputValue();
+        }
     }
 
     // Set the value of the input component.

--- a/src/pin-field/PinField.ts
+++ b/src/pin-field/PinField.ts
@@ -1,4 +1,4 @@
-import { css, html } from 'lit';
+import { PropertyValueMap, css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { OmniFormElement } from '../core/OmniFormElement.js';
@@ -83,7 +83,6 @@ export class PinField extends OmniFormElement {
     private showPin?: boolean = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private isWebkit?: boolean;
-    private _value? = '';
 
     override connectedCallback() {
         super.connectedCallback();
@@ -110,6 +109,19 @@ export class PinField extends OmniFormElement {
         this._sanitiseValue();
     }
 
+    protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
+        if (_changedProperties.has('value')) {
+            if (this.value) {
+                this.container?.classList?.add('float-label');
+                this.container?.classList?.remove('no-float-label');
+            } else {
+                this.container?.classList?.remove('float-label');
+                this.container?.classList?.add('no-float-label');
+            }
+            this._sanitiseValue();
+        }
+    }
+
     override focus(options?: FocusOptions | undefined): void {
         if (this._inputElement) {
             this._inputElement.focus(options);
@@ -118,37 +130,17 @@ export class PinField extends OmniFormElement {
         }
     }
 
-    constructor() {
-        super();
-        this._value = this.value ?? '';
-        Object.defineProperty(this, 'value', {
-            get: () => {
-                return this._value;
-            },
-            set: (v) => {
-                this._value = v ?? '';
-                this._sanitiseValue();
-                if (this._value) {
-                    this.container?.classList?.add('float-label');
-                    this.container?.classList?.remove('no-float-label');
-                } else {
-                    this.container?.classList?.remove('float-label');
-                    this.container?.classList?.add('no-float-label');
-                }
-                this.requestUpdate();
-            }
-        });
-    }
-
     // Check if the value provided is valid and shorten according to the max length if provided, if there is invalid alpha characters they are removed.
     _sanitiseValue() {
         if (this.value) {
             if (this.maxLength && (this.value as string).length > this.maxLength) {
-                this._value = this.value?.slice(0, this.maxLength) as string;
+                this.value = this.value?.slice(0, this.maxLength) as string;
             }
+        } else {
+            this.value = '';
         }
 
-        this._value = this.value?.toString()?.replace(/[^\d]/gi, '');
+        this.value = this.value?.toString()?.replace(/[^\d]/gi, '');
 
         if (this._inputElement) {
             this._inputElement.value = this.value as string;


### PR DESCRIPTION
### Description:

closes #188 

Issue picked when projects updated to use the latest version of Omni-components. This resulted in the Password and Pin Field components to not render on screen and a error logged to the console.

![image](https://github.com/capitec/omni-components/assets/22874454/1ff3e5a9-f457-4eba-9e44-7c7d51133ef7)

The original issues that needed to be resolved 

- Set the value property to not reflect in the DOM.
- Add functionality to handle the floating label as the CSS styles were applied based on the value attribute.

The new implementation covers the above requirements and resolves the rendering issue. 

### Screenshots (if appropriate):

**Test Results** 

Pin Field 

![image](https://github.com/capitec/omni-components/assets/22874454/39fcd29a-6c41-4178-811a-10bca11c4c6b)

Password Field

![image](https://github.com/capitec/omni-components/assets/22874454/0ab8a1e6-8bd2-489f-8134-6523625ed4fc)

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
