### PR TITLE
Date picker formats selected value inconsistently.

### DIFF
--- a/src/date-picker/DatePicker.ts
+++ b/src/date-picker/DatePicker.ts
@@ -227,7 +227,7 @@ export class DatePicker extends OmniFormElement {
     }
 
     _dateSelected(e: Event) {
-        this.date = DateTime.fromJSDate((<CustomEvent>e).detail.date);
+        this.date = DateTime.fromJSDate((<CustomEvent>e).detail.date).setLocale(this.locale);
 
         this.value = this.date.toISODate() as string;
 


### PR DESCRIPTION
### Description:

closes #131 

Issue occurs when a user selects the same date twice. the intial selection is formatted to display '<month> <day>, <year>'

eg: October 19, 2023

After selecting the same date the value displayed in the Date picker formats incorrectly '<day> <month> <year>'

eg: 19 October 2023

### Screenshots (if appropriate):

**First date selection** 

![image](https://github.com/capitec/omni-components/assets/22874454/f7c2200a-c28d-48af-96f7-36be4da10d85)

**Second selection** 

![image](https://github.com/capitec/omni-components/assets/22874454/16a7feb2-8486-4604-acd9-730e8ee0d82e)

Test Results for Date Picker tests

![image](https://github.com/capitec/omni-components/assets/22874454/51ef514f-0b2b-4448-9bd7-c6ccfb5f9424)

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
