### PR TITLE
Update components using dialog element to prevent dialog closing when pressing the esc key

### DIFF
--- a/src/date-picker/DatePicker.ts
+++ b/src/date-picker/DatePicker.ts
@@ -423,7 +423,7 @@ export class DatePicker extends OmniFormElement {
     protected override renderPicker() {
         if (this._isMobile) {
             return html`
-            <dialog id="picker-dialog" class="picker-dialog">
+            <dialog id="picker-dialog" class="picker-dialog" @cancel="${(e: Event) => e.preventDefault()}">
                 <omni-calendar 
                     id="calendar" 
                     locale=${this.locale} 

--- a/src/modal/Modal.ts
+++ b/src/modal/Modal.ts
@@ -197,9 +197,15 @@ export class Modal extends OmniElement {
         // `HTMLDialogElement` needs to programmatically be opened and closed. This would open on first render unless the `hide` attribute is set.
         if (!this.hide && !this.dialog.open) {
             this.dialog.showModal();
+            this.dialog.addEventListener('cancel', (event) => {
+                event.preventDefault();
+            });
         }
         if (this.hide && this.dialog.open) {
             this.dialog.close();
+            this.dialog.removeEventListener('cancel', () => {
+                /*No function logic required*/
+            });
         }
     }
 

--- a/src/modal/Modal.ts
+++ b/src/modal/Modal.ts
@@ -197,15 +197,9 @@ export class Modal extends OmniElement {
         // `HTMLDialogElement` needs to programmatically be opened and closed. This would open on first render unless the `hide` attribute is set.
         if (!this.hide && !this.dialog.open) {
             this.dialog.showModal();
-            this.dialog.addEventListener('cancel', (event) => {
-                event.preventDefault();
-            });
         }
         if (this.hide && this.dialog.open) {
             this.dialog.close();
-            this.dialog.removeEventListener('cancel', () => {
-                /*No function logic required*/
-            });
         }
     }
 
@@ -351,6 +345,7 @@ export class Modal extends OmniElement {
     override render(): TemplateResult {
         return html`
             <dialog part="dialog" class="modal" role="dialog" aria-modal="true"
+                    @cancel="${(e: Event) => e.preventDefault()}"
                     @click="${(e: Event) => this.notifyClickOutside(e)}" @touch="${(e: Event) => this.notifyClickOutside(e)}">
                 <div class="modal backdrop" part="backdrop">
                     <div class="container" ?no-fullscreen="${this.noFullscreen}" part="container">

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -711,7 +711,7 @@ export class Select extends OmniFormElement {
     protected override renderPicker() {
         if (this._isMobile) {
             return html`
-            <dialog id="items-dialog" class="items-dialog">
+            <dialog id="items-dialog" class="items-dialog" @cancel="${(e: Event) => e.preventDefault()}">
                 ${this._isMobile && this.label ? html`<div class="header">${this.label}</div>` : nothing}
                 ${this._renderSearchField()}
                 <div ${ref(this._itemsMaxHeightChange)} id="items" class="items"> ${until(


### PR DESCRIPTION
### Description:

closes #195 

Issue raised by project that leverages the modal component. The team raised that the escape key should not have the capability of closing a dialog element. 

The solution is to prevent default behaviour when a cancel event is emitted.

The same solution is implemented in components that leverage a html dialog element

- DatePicker
- Select 

### Test result screenshots:

**DatePicker**
<img width="174" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/b658e7bf-6e5e-4c47-9e95-47d73d580fa8">

**Select**
<img width="174" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/eee83bc1-5739-4f79-8a08-ee8b56a39441">

**Modal**
<img width="174" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/a7fbdea2-1905-4282-b711-c65e24ec4b8c">


### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.

### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
