### PR TITLE
Fixed Tab group header to be scrollable 

### DIFF
--- a/src/tab/TabGroup.ts
+++ b/src/tab/TabGroup.ts
@@ -150,6 +150,8 @@ export class TabGroup extends OmniElement {
                     display: flex;
                     flex-direction: row;
                     align-items: center;
+                    overflow-x: auto;
+                    overflow-y: hidden;
                     width: var(--omni-tab-group-tab-bar-width, 100%);
                     height: var(--omni-tab-group-tab-bar-height, 50px);
                     border-bottom: var(--omni-tab-group-tab-bar-border-bottom, none);

--- a/src/tab/TabGroup.ts
+++ b/src/tab/TabGroup.ts
@@ -36,6 +36,8 @@ import { TabHeader } from './TabHeader.js';
  * @slot - All omni-tab components that are managed by this component.
  * @slot header - Optional omni-tab-header components associated with each omni-tab component.
  *
+ * @cssprop --omni-tab-group-tab-bar-overflow-x - Tabs tab bar overflow x.
+ * @cssprop --omni-tab-group-tab-bar-overflow-y - Tabs tab bar overflow y.
  * @cssprop --omni-tab-group-tab-bar-width - Tabs tab bar width.
  * @cssprop --omni-tab-group-tab-bar-height - Tabs tab bar height.
  * @cssprop --omni-tab-group-tab-bar-border-bottom - Tabs tab bar bottom border.
@@ -150,8 +152,8 @@ export class TabGroup extends OmniElement {
                     display: flex;
                     flex-direction: row;
                     align-items: center;
-                    overflow-x: auto;
-                    overflow-y: hidden;
+                    overflow-x: var(--omni-tab-group-tab-bar-overflow-x, auto);
+                    overflow-y: var(--omni-tab-group-tab-bar-overflow-y, hidden);
                     width: var(--omni-tab-group-tab-bar-width, 100%);
                     height: var(--omni-tab-group-tab-bar-height, 50px);
                     border-bottom: var(--omni-tab-group-tab-bar-border-bottom, none);


### PR DESCRIPTION
### Description:

closes #198 

Issue raised by project using Omni-components when rendering the Tab related components in a containing element with a limited width the tab headers render off screen. 

The component needs to introduce the ability to scroll the tab headers to allow interaction with tabs that are not in view.

### Screenshots (if appropriate):

Issue demonstrated on the doc site, for the purposes of this test we limited the max width of the interactive story to have a max-width of 400px and have 12 nested tabs;

**Before** 

<img width="835" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/830d5e1f-15e7-4d09-a0e8-50800c261632">

**After**

<img width="857" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/37422d55-ffcc-41cf-9e97-cd17a1c8a01b">

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [x] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [x] I have added/updated docs, as applicable.
