### PR TITLE
Bug: Tab components header size bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,12 @@ A vulnerability is typically a security-related risk associated with *any part* 
 1. [Fork](https://github.com/capitec/omni-components/fork) the repository and create a new branch from `develop` (Do not directly use `develop` as this will prevent certain workflows from being triggered).
 2. Go to the Actions tab and enable workflow runs for the repository. (This is needed to generate screenshots for tests)
 
-    <img src="./.github/assets/enable-workflows.png" alt="Enabling Workflows" style="max-width: 100%; width: auto;"/>
+    <img src="https://github.com/capitec/omni-components/blob/main/.github/assets/enable-workflows.png?raw=true" alt="Enabling Workflows" style="max-width: 100%; width: auto;"/>
 3. Add a `PROTECTED_TOKEN` secret for workflow runs with a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) as its value. (Optional)
     - This is to enable re-triggering of workflows when a workflow commits screenshots. If this is not set a new code commit will be required to trigger the next workflow as it uses the default `GITHUB_TOKEN` instead.
     - See [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) for detail.
     
-    <img src="./.github/assets/protected-token-creation.gif" alt="Protected token creation" style="max-width: 100%; width: auto;"/>
+    <img src="https://github.com/capitec/omni-components/blob/main/.github/assets/protected-token-creation.gif?raw=true" alt="Protected token creation" style="max-width: 100%; width: auto;"/>
 4. Clone the forked repo, checkout your branch, and run `npm ci` inside the repository root.
 5. Install the testing dependencies with `npx playwright install --with-deps`.
 6. Start up the dev server with `npm run serve` (or by launching debugging in VS Code).
@@ -203,7 +203,7 @@ npx playwright test Component.spec.ts
 ```sh
 npm run test-results 
 ```
-<img src="./.github/assets/test-results-report.gif" alt="Test Report" style="max-width: 100%; width: auto;"/>
+<img src="https://github.com/capitec/omni-components/blob/main/.github/assets/test-results-report.gif?raw=true" alt="Test Report" style="max-width: 100%; width: auto;"/>
 
 > 🔶 NOTE: Screenshot testing only asserts during CI workflows, the report will locally only show current screenshots taken, but not perform any comparisons.
 

--- a/src/tab/TabGroup.ts
+++ b/src/tab/TabGroup.ts
@@ -150,6 +150,7 @@ export class TabGroup extends OmniElement {
                 /* Tab bar */
                 :host > .tab-bar {
                     display: flex;
+                    flex-shrink: 0;
                     flex-direction: row;
                     align-items: center;
                     overflow-x: var(--omni-tab-group-tab-bar-overflow-x, auto);

--- a/src/tab/TabHeader.ts
+++ b/src/tab/TabHeader.ts
@@ -118,6 +118,7 @@ export class TabHeader extends OmniElement {
             
 
                 :host > .indicator-bar {
+                    flex-shrink: 0;
                     height: var(--omni-tab-header-indicator-bar-height, 4px);
                     border-radius: var(--omni-tab-header-indicator-bar-border-radius, 100px 100px 0 0);
                     width: var(--omni-tab-header-indicator-bar-width, 100%);


### PR DESCRIPTION
### Description:

closes #208 

Currently the Tab related components has a unwanted height size adjustment when the tab header is focussed or not. This was discovered when testing on a mobile device.

Update to path for images in Contributing guide updated (currently these images do not display). 

Current state after update deployed to alpha

https://github.com/capitec/omni-components/assets/22874454/e0cca7a7-f16f-4934-880a-186dfe84906e

### Screenshots (if appropriate):

Tab test results

<img width="181" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/d7b2a478-bd92-43d9-a6e7-cc3746f8b6cf">

Tab Header test results

<img width="181" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/902e390b-b3f0-4b98-ba06-c98eaf8a5fa0">

Tab Group test results

<img width="181" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/009d2cb3-faf3-49d9-973d-2c25d7c44e50">

Before 

https://github.com/capitec/omni-components/assets/22874454/c07804e9-506b-49b0-9574-5f32fea414c5

After 

https://github.com/capitec/omni-components/assets/22874454/bc5a9319-3a3f-4a26-a86c-29e3e73179c0


### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [ ] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [ ] I have added/updated docs, as applicable.
