### PR TITLE
Bug: Add blur on enter on `omni-text-field` component

### DIFF
--- a/src/text-field/TextField.ts
+++ b/src/text-field/TextField.ts
@@ -54,6 +54,9 @@ export class TextField extends OmniFormElement {
         this.addEventListener('input', this._keyInput.bind(this), {
             capture: true
         });
+        this.addEventListener('keyup', this._blurOnEnter.bind(this), {
+            capture: true
+        });
     }
 
     override focus(options?: FocusOptions | undefined): void {
@@ -61,6 +64,12 @@ export class TextField extends OmniFormElement {
             this._inputElement.focus(options);
         } else {
             super.focus(options);
+        }
+    }
+
+    _blurOnEnter(e: KeyboardEvent) {
+        if (e.code === 'Enter' || e.keyCode === 13) {
+            (e.currentTarget as HTMLElement).blur();
         }
     }
 


### PR DESCRIPTION
### Description:

closes #179 

Issue raised on mobile application using the omni-text-field component.

Note this issue will not occur on more modern devices as these devices will have a "next" button which will focus the next input component vs a "enter" button.

### Screenshots (if appropriate):

<img width="181" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/b6f94eae-056e-4595-a87f-ac81c4c5308e">


For the testing of this use case it was done using developer tools in the chrome browser this is not close to a real world scenario although the issue can be demonstrated 

Values are typed in a the omni-text-field component and then the enter key is pressed on the keyboard.

Before 

https://github.com/capitec/omni-components/assets/22874454/69707c9a-3d12-4d4e-9551-708a57c17861

After

https://github.com/capitec/omni-components/assets/22874454/ccf2ebea-4a1c-441b-b1da-56a207e9f14f


**IPhone Tests** 

Before 

https://github.com/capitec/omni-components/assets/22874454/233cc416-5b99-493d-b324-3f1bdd4bc01d

After

https://github.com/capitec/omni-components/assets/22874454/3088d9b2-61d7-4cf1-86d2-6b3ecad1cc7a


### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [ ] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [ ] I have added/updated docs, as applicable.
