### PR TITLE
Hotfix - Update omni-currency-field logic to support backward compatible browsers

### DIFF
--- a/src/currency-field/CurrencyField.ts
+++ b/src/currency-field/CurrencyField.ts
@@ -174,7 +174,7 @@ export class CurrencyField extends OmniFormElement {
 
     // Convert given value to cents.
     _convertToCents(currencyValue: string) {
-        return currencyValue.replace(this.fractionalSeparator, '').replaceAll(this.thousandsSeparator, '');
+        return currencyValue.replace(this.fractionalSeparator, '').replace(new RegExp(this.thousandsSeparator, 'g'), '');
     }
 
     // Format to a full currency value with whole amount and cents.


### PR DESCRIPTION
### Description:

Issue picked up on mobile device running on older version of chrome browser. 

The previous implemented hardening of the `omni-currency-field` component introduced unwanted behaviour which results in the formatting and cursor positioning not working correctly.

The issue was discovered to be a 'replaceAll' function which will not work on older browsers the implementation has since been updated to cater for this change.

### Screenshots (if appropriate):

<img width="142" alt="image" src="https://github.com/capitec/omni-components/assets/22874454/2bcf3cbd-c8c1-4542-96b3-4781dedea1f2">

### All Submissions:

* [x] I have followed the [contribution guidelines](https://github.com/capitec/omni-components/blob/develop/CONTRIBUTING.md) for this project.
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.


### Changes to Core Features:

* [x] I have added an explanation of what my changes do and why I would like to include them.
* [ ] I have written new tests for my core changes, as applicable.
* [x] I have successfully ran tests with my changes locally.
* [ ] I have added/updated docs, as applicable.
